### PR TITLE
Add video and audio detectors with automated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,48 @@ pnpm tsx src/app.ts
 
 Oluşturulan olay günlüğünü `data/events.sqlite` içinde görebilir veya SQLite araçlarıyla sorgulayabilirsiniz.
 
-## Video testi
+## Video testleri ve dedektörleri
 
-Varsayılan yapılandırma `assets/test-video.mp4` yoluna yazılan küçük bir örnek videoyu saniyede iki kare olacak şekilde PNG formatında ayrıştırır ve en son kareyi `snapshots/last.png` dosyasına yazar. Dosya mevcut değilse komut otomatik olarak oluşturur. Aşağıdaki komut gerçek zamanlı kareleri üreterek `snapshots/last.png` dosyasını periyodik olarak günceller:
+Varsayılan yapılandırma `assets/test-video.mp4` yoluna yazılan küçük bir örnek videoyu saniyede iki kare olacak şekilde PNG formatında ayrıştırır. `pnpm tsx src/run-video-detectors.ts` komutu bu akışı Motion ve Light dedektörleriyle analiz eder.
+
+Dedektörler, olay yakalandığında `event` kanalına olay düşer ve otomatik olarak SQLite veritabanına kaydedilir.
+
+### MotionDetector
+
+- **diffThreshold**: Piksel başına minimum fark (varsayılan 25). Bu değeri azaltmak küçük hareketleri yakalar, yükseltmek gürültüyü filtreler.
+- **areaThreshold**: Toplam kareye göre yüzde olarak değişen piksel oranı (varsayılan %1.5). %0.02 = %2 alan anlamına gelir.
+- **minIntervalMs**: Aynı hareketin tekrar raporlanmaması için minimum bekleme süresi.
+
+### LightDetector
+
+- **deltaThreshold**: Ortalama lüminansta beklenmeyen sıçramayı tetikleyen fark (varsayılan 40/255).
+- **normalHours**: Aydınlığın normal kabul edildiği saat aralıkları. Saatler dışında kalan tüm değişimler eşik ile karşılaştırılır. Örneğin `{ start: 7, end: 22 }` gündüz ışığını, `{ start: 22, end: 6 }` gece ışığını tanımlar.
+- **smoothingFactor**: Lüminans baz çizgisini yumuşatmak için EMA katsayısı.
+- **minIntervalMs**: Aynı ışık olayının tekrarlanmasını sınırlar.
+
+### PersonDetector
+
+- **modelPath**: `models/yolov8n.onnx` benzeri YOLOv8 tabanlı ONNX modelinin yolu. Model dosyasını bu klasöre kendiniz yerleştirmelisiniz.
+- **score**: Kişi sınıfı için minimum güven skoru. Örneğin `0.5` üzerindeki sonuçlar kişi olarak raporlanır.
+- **checkEveryNFrames**: Hareket algılandıktan sonra her N. karede kişi analizi yapılır.
+- **maxDetections**: Tek bir hareket tetiklemesinden sonra kaç kareye kadar kişi analizi yapılacağını sınırlar.
+- **snapshotDir**: `snapshots/` varsayılanına yazılan kişi görüntülerinin klasörü.
+
+Dedektör, kareleri 640x640 çözünürlüğe `letterbox` yöntemiyle ölçeklendirir ve YOLOv8 çıktısındaki kişi skorunu eşiğin üzerinde bulduğunda `snapshots/<timestamp>-person.png` dosyası oluşturup olaya kutu koordinatlarını ekler.
+
+Farklı bir test videosu veya kare hızı kullanmak isterseniz `config/default.json` altındaki `video.testFile` ve `video.framesPerSecond` ayarlarını güncelleyin. Dedektör eşikleri kod içinde parametre olarak belirtilmiştir, gerekirse scripti düzenleyin.
+
+Örnek komut:
 
 ```bash
-pnpm tsx src/video/index.ts
+pnpm tsx src/run-video-detectors.ts
 ```
 
-Farklı bir test videosu veya kare hızı kullanmak isterseniz `config/default.json` altındaki `video.testFile` ve `video.framesPerSecond` ayarlarını güncelleyin.
+Örnek video üzerinde bu komut en az bir motion veya light olayını terminale ve veritabanına yazar.
+
+## Hareket → kişi tetik zinciri
+
+`pnpm tsx src/run-guard.ts` komutu, MotionDetector tetiklendikten sonra yapılandırmadaki her `checkEveryNFrames` karede PersonDetector'ı devreye alır. Maksimum deneme sayısı aşılana kadar kişi analizleri sürer. Eşik aşılırsa olay kayıt defterine kişi olayı düşer ve eş zamanlı olarak snapshot klasöründe görüntü saklanır.
 
 ## Testler
 
@@ -37,6 +70,29 @@ Birimin doğru kare ayrıştırmasını doğrulamak için Vitest testleri bulunm
 ```bash
 pnpm vitest run -t Bootstrap
 pnpm vitest run -t VideoSource
+pnpm vitest run -t "(Motion|Light)Detector"
+pnpm vitest run -t AudioAnomaly
+pnpm vitest run -t PersonDetector
 ```
 
-`Bootstrap` testi uygulama başlangıcını, `VideoSource` testi ise sahte bir PNG akışını doğrular.
+`Bootstrap` testi uygulama başlangıcını, `VideoSource` testi sahte bir PNG akışını; `MotionDetector` ve `LightDetector` sentetik karelerle video eşiklerini; `PersonDetector` hareket sonrası kişi senaryosunu; `AudioAnomaly` ise sentetik PCM örnekleriyle ses dedektörünü doğrular.
+
+## Ses dedektörü
+
+`pnpm tsx src/run-audio-detector.ts` komutu mikrofon akışını (veya uygun şekilde yönlendirilmiş `ffmpeg` girişini) 16 kHz tek kanal PCM formatında alır ve RMS / spektral centroid (Meyda ile) hesaplayarak olağan dışı durumlarda `audio-anomaly` olayı üretir.
+
+Varsayılan olarak işletim sistemine göre şu ffmpeg seçenekleri kullanılır:
+
+- **Linux (ALSA)**: `-f alsa -i default`
+- **macOS (AVFoundation)**: `-f avfoundation -i :0`
+- **Windows (DirectShow)**: `-f dshow -i audio="default"`
+
+Ses dedektöründe kullanılan temel parametreler:
+
+- **rmsThreshold** ≈ 0.25: Ses seviyesinin (0-1 aralığı) aşması hâlinde `critical` seviye üretir.
+- **centroidJumpThreshold** ≈ 200 Hz: Spektral centroidte ani sıçramaları `warning` olarak raporlar.
+- **minIntervalMs**: Aynı anomali tekrarının bastırılması için bekleme süresi.
+
+Farklı bir cihaz kullanmak istiyorsanız `src/run-audio-detector.ts` içindeki `AudioSource` yapılandırmasını güncelleyin. Windows kullanıcılarının ffmpeg'in DirectShow cihaz adını doğru girdiğinden emin olması gerekir (`ffmpeg -list_devices true -f dshow -i dummy`). ALSA altında sanal cihaz veya `plughw` kullanabilirsiniz. Ayrıca `type: 'ffmpeg'` seçeneği ile boru hattından (`pipe:0`) gelen PCM akışları da okunabilir.
+
+Komut çalışırken el çırpma veya ani ses değişimleri en az bir `audio-anomaly` olayını oluşturur.

--- a/config/default.json
+++ b/config/default.json
@@ -18,5 +18,12 @@
   "video": {
     "testFile": "assets/test-video.mp4",
     "framesPerSecond": 2
+  },
+  "person": {
+    "modelPath": "models/yolov8n.onnx",
+    "score": 0.5,
+    "checkEveryNFrames": 3,
+    "maxDetections": 5,
+    "snapshotDir": "snapshots"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "config": "^3.3.9",
     "ffmpeg-static": "^5.2.0",
     "fluent-ffmpeg": "^2.1.2",
-    "pino": "^8.17.0"
+    "meyda": "^5.6.3",
+    "onnxruntime-node": "1.22.0-rev",
+    "pino": "^8.17.0",
+    "pngjs": "^7.0.0"
   },
   "devDependencies": {
     "@types/config": "^3.3.4",
@@ -27,6 +30,9 @@
       "better-sqlite3",
       "esbuild",
       "ffmpeg-static"
+    ],
+    "ignoredBuiltDependencies": [
+      "onnxruntime-node"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,18 @@ importers:
       fluent-ffmpeg:
         specifier: ^2.1.2
         version: 2.1.3
+      meyda:
+        specifier: ^5.6.3
+        version: 5.6.3(rollup@4.52.2)
+      onnxruntime-node:
+        specifier: 1.22.0-rev
+        version: 1.22.0-rev
       pino:
         specifier: ^8.17.0
         version: 8.21.0
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
     devDependencies:
       '@types/config':
         specifier: ^3.3.4
@@ -350,6 +359,24 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@rollup/plugin-node-resolve@15.3.1':
+    resolution: {integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.52.2':
     resolution: {integrity: sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==}
     cpu: [arm]
@@ -478,6 +505,9 @@ packages:
   '@types/node@20.19.17':
     resolution: {integrity: sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==}
 
+  '@types/resolve@1.20.2':
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
 
@@ -506,6 +536,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.16:
+    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+    engines: {node: '>=12.0'}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -524,6 +558,9 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  babel-plugin-add-module-exports@0.2.1:
+    resolution: {integrity: sha512-3AN/9V/rKuv90NG65m4tTHsI04XrCKsWbztIcW7a8H5iIN7WlvWucRtVV0V/rT4QvtA11n5Vmp20fLwfMWqp6g==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -535,6 +572,19 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  buffer-alloc-unsafe@1.1.0:
+    resolution: {integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==}
+
+  buffer-alloc@1.2.0:
+    resolution: {integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==}
+
+  buffer-fill@1.0.0:
+    resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -573,9 +623,24 @@ packages:
     resolution: {integrity: sha512-Vmx389R/QVM3foxqBzXO8t2tUikYZP64Q6vQxGrsMpREeJc/aWRnPRERXWsYzOHAumx/AOoILWe6nU3ZJL+6Sw==}
     engines: {node: '>= 10.0.0'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  dct@0.1.0:
+    resolution: {integrity: sha512-/uUtEniuMq1aUxvLAoDtAduyl12oM1zhA/le2f83UFN/9+4KDHXFB6znEfoj5SDDLiTpUTr26NpxC7t8IFOYhQ==}
+    engines: {node: '>=0.12.0'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -598,9 +663,24 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
   detect-libc@2.1.0:
     resolution: {integrity: sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==}
     engines: {node: '>=8'}
+
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -613,6 +693,17 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -622,6 +713,13 @@ packages:
     resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -650,6 +748,9 @@ packages:
     resolution: {integrity: sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==}
     engines: {node: '>=16'}
 
+  fftjs@0.0.4:
+    resolution: {integrity: sha512-nIWxQyth1LVD6NH8a+YZUv+McjzbOY6dMe4wv6Pq5cGfP+c8Rd1T8Dsd50DCWlNgzSqA3y9lOkpD6dZD3qHa1A==}
+
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
@@ -666,6 +767,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
@@ -678,6 +782,25 @@ packages:
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   http-response-object@3.0.2:
     resolution: {integrity: sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==}
@@ -699,15 +822,28 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  is-module@1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  isarray@0.0.1:
+    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -724,8 +860,16 @@ packages:
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  meyda@5.6.3:
+    resolution: {integrity: sha512-fAdwfzIi1WDoL0idUQvCD7dZ7EN74FYH83G+jZQO3Nr9yOEBtzFvcMg2KLdLlu6psSP8XFlO0kYynG5o/E681Q==}
+    hasBin: true
 
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
@@ -744,6 +888,9 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -759,9 +906,17 @@ packages:
     resolution: {integrity: sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==}
     engines: {node: '>=10'}
 
+  node-getopt@0.3.2:
+    resolution: {integrity: sha512-yqkmYrMbK1wPrfz7mgeYvA4tBperLg9FQ4S3Sau3nSAkpOA0x0zC8nQ1siBwozy1f4SE8vq2n1WKv99r+PCa1Q==}
+    engines: {node: '>= 0.6.0'}
+
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -773,6 +928,13 @@ packages:
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
+
+  onnxruntime-common@1.22.0:
+    resolution: {integrity: sha512-vcuaNWgtF2dGQu/EP5P8UI5rEPEYqXG2sPPe5j9lg2TY/biJF8eWklTMwlDO08iuXq48xJo0awqIpK5mPG+IxA==}
+
+  onnxruntime-node@1.22.0-rev:
+    resolution: {integrity: sha512-9vh50/mnwauFUex0NYyyLf9pmRp8q6DVMG8K+xtoXv68SSB9bESa1bEbWLqfUncgB3XucQaOV+wfMPcqANMYhQ==}
+    os: [win32, darwin, linux]
 
   p-limit@5.0.0:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
@@ -789,6 +951,9 @@ packages:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
@@ -800,6 +965,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   pino-abstract-transport@1.2.0:
     resolution: {integrity: sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==}
@@ -813,6 +982,10 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -851,6 +1024,9 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  readable-stream@1.1.14:
+    resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -866,6 +1042,15 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
+
   rollup@4.52.2:
     resolution: {integrity: sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -878,10 +1063,17 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -915,11 +1107,20 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  stream-parser@0.3.1:
+    resolution: {integrity: sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==}
+
+  string_decoder@0.10.31:
+    resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -934,6 +1135,10 @@ packages:
 
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
@@ -967,6 +1172,10 @@ packages:
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -1045,6 +1254,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  wav@1.0.2:
+    resolution: {integrity: sha512-viHtz3cDd/Tcr/HbNqzQCofKdF6kWUymH9LGDdskfWFoIy/HJ+RTihgjEcHfnsy1PO4e9B+y4HwgTwMrByquhg==}
 
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -1229,6 +1441,24 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@rollup/plugin-node-resolve@15.3.1(rollup@4.52.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.2)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-module: 1.0.0
+      resolve: 1.22.10
+    optionalDependencies:
+      rollup: 4.52.2
+
+  '@rollup/pluginutils@5.3.0(rollup@4.52.2)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.52.2
+
   '@rollup/rollup-android-arm-eabi@4.52.2':
     optional: true
 
@@ -1311,6 +1541,8 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/resolve@1.20.2': {}
+
   '@vitest/expect@1.6.1':
     dependencies:
       '@vitest/spy': 1.6.1
@@ -1350,6 +1582,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  adm-zip@0.5.16: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -1363,6 +1597,8 @@ snapshots:
   async@0.2.10: {}
 
   atomic-sleep@1.0.0: {}
+
+  babel-plugin-add-module-exports@0.2.1: {}
 
   base64-js@1.5.1: {}
 
@@ -1380,6 +1616,17 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  boolean@3.2.0: {}
+
+  buffer-alloc-unsafe@1.1.0: {}
+
+  buffer-alloc@1.2.0:
+    dependencies:
+      buffer-alloc-unsafe: 1.1.0
+      buffer-fill: 1.0.0
+
+  buffer-fill@1.0.0: {}
 
   buffer-from@1.1.2: {}
 
@@ -1426,11 +1673,19 @@ snapshots:
     dependencies:
       json5: 2.2.3
 
+  core-util-is@1.0.3: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  dct@0.1.0: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
 
   debug@4.4.3:
     dependencies:
@@ -1446,7 +1701,23 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
+  deepmerge@4.3.1: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
   detect-libc@2.1.0: {}
+
+  detect-node@2.1.0: {}
 
   diff-sequences@29.6.3: {}
 
@@ -1455,6 +1726,12 @@ snapshots:
       once: 1.4.0
 
   env-paths@2.2.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es6-error@4.1.1: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -1511,6 +1788,10 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.10
       '@esbuild/win32-x64': 0.25.10
 
+  escape-string-regexp@4.0.0: {}
+
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -1544,6 +1825,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fftjs@0.0.4:
+    dependencies:
+      babel-plugin-add-module-exports: 0.2.1
+
   file-uri-to-path@1.0.0: {}
 
   fluent-ffmpeg@2.1.3:
@@ -1556,6 +1841,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-func-name@2.0.2: {}
 
   get-stream@8.0.1: {}
@@ -1565,6 +1852,30 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   github-from-package@0.0.0: {}
+
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.7.2
+      serialize-error: 7.0.1
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
+  gopd@1.2.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   http-response-object@3.0.2:
     dependencies:
@@ -1585,11 +1896,21 @@ snapshots:
 
   ini@1.3.8: {}
 
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
+
+  is-module@1.0.0: {}
+
   is-stream@3.0.0: {}
+
+  isarray@0.0.1: {}
 
   isexe@2.0.0: {}
 
   js-tokens@9.0.1: {}
+
+  json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
 
@@ -1606,7 +1927,22 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+
   merge-stream@2.0.0: {}
+
+  meyda@5.6.3(rollup@4.52.2):
+    dependencies:
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.52.2)
+      dct: 0.1.0
+      fftjs: 0.0.4
+      node-getopt: 0.3.2
+      wav: 1.0.2
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
 
   mimic-fn@4.0.0: {}
 
@@ -1623,6 +1959,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -1633,9 +1971,13 @@ snapshots:
     dependencies:
       semver: 7.7.2
 
+  node-getopt@0.3.2: {}
+
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
+
+  object-keys@1.1.1: {}
 
   on-exit-leak-free@2.1.2: {}
 
@@ -1647,6 +1989,14 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
+  onnxruntime-common@1.22.0: {}
+
+  onnxruntime-node@1.22.0-rev:
+    dependencies:
+      adm-zip: 0.5.16
+      global-agent: 3.0.0
+      onnxruntime-common: 1.22.0
+
   p-limit@5.0.0:
     dependencies:
       yocto-queue: 1.2.1
@@ -1657,6 +2007,8 @@ snapshots:
 
   path-key@4.0.0: {}
 
+  path-parse@1.0.7: {}
+
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
@@ -1664,6 +2016,8 @@ snapshots:
   pathval@1.1.1: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
 
   pino-abstract-transport@1.2.0:
     dependencies:
@@ -1691,6 +2045,8 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  pngjs@7.0.0: {}
 
   postcss@8.5.6:
     dependencies:
@@ -1741,6 +2097,13 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  readable-stream@1.1.14:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 0.0.1
+      string_decoder: 0.10.31
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -1758,6 +2121,21 @@ snapshots:
   real-require@0.2.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
 
   rollup@4.52.2:
     dependencies:
@@ -1791,7 +2169,13 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
+  semver-compare@1.0.0: {}
+
   semver@7.7.2: {}
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
 
   shebang-command@2.0.0:
     dependencies:
@@ -1819,9 +2203,19 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sprintf-js@1.1.3: {}
+
   stackback@0.0.2: {}
 
   std-env@3.9.0: {}
+
+  stream-parser@0.3.1:
+    dependencies:
+      debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
+
+  string_decoder@0.10.31: {}
 
   string_decoder@1.3.0:
     dependencies:
@@ -1834,6 +2228,8 @@ snapshots:
   strip-literal@2.1.1:
     dependencies:
       js-tokens: 9.0.1
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   tar-fs@2.1.4:
     dependencies:
@@ -1872,6 +2268,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   type-detect@4.1.0: {}
+
+  type-fest@0.13.1: {}
 
   typedarray@0.0.6: {}
 
@@ -1943,6 +2341,16 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  wav@1.0.2:
+    dependencies:
+      buffer-alloc: 1.2.0
+      buffer-from: 1.1.2
+      debug: 2.6.9
+      readable-stream: 1.1.14
+      stream-parser: 0.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   which@1.3.1:
     dependencies:

--- a/src/audio/anomaly.ts
+++ b/src/audio/anomaly.ts
@@ -1,0 +1,91 @@
+import { EventEmitter } from 'node:events';
+import Meyda from 'meyda';
+import eventBus from '../eventBus.js';
+import { EventPayload } from '../types.js';
+
+export interface AudioAnomalyOptions {
+  source: string;
+  sampleRate?: number;
+  rmsThreshold?: number;
+  centroidJumpThreshold?: number;
+  minIntervalMs?: number;
+}
+
+const DEFAULT_SAMPLE_RATE = 16000;
+const DEFAULT_RMS_THRESHOLD = 0.2;
+const DEFAULT_CENTROID_JUMP = 150;
+const DEFAULT_MIN_INTERVAL_MS = 1500;
+
+export class AudioAnomalyDetector {
+  private previousCentroid: number | null = null;
+  private lastEventTs = 0;
+
+  constructor(
+    private readonly options: AudioAnomalyOptions,
+    private readonly bus: EventEmitter = eventBus
+  ) {}
+
+  handleChunk(samples: Int16Array, ts = Date.now()) {
+    const sampleRate = this.options.sampleRate ?? DEFAULT_SAMPLE_RATE;
+    const normalized = normalizeSamples(samples);
+    const features = Meyda.extract(['rms', 'spectralCentroid'], normalized, {
+      sampleRate,
+      bufferSize: normalized.length
+    });
+
+    if (!features) {
+      return;
+    }
+
+    const rmsThreshold = this.options.rmsThreshold ?? DEFAULT_RMS_THRESHOLD;
+    const centroidJump = this.options.centroidJumpThreshold ?? DEFAULT_CENTROID_JUMP;
+    const minInterval = this.options.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+
+    const rms = features.rms ?? 0;
+    const centroid = features.spectralCentroid ?? 0;
+
+    const triggeredByRms = rms > rmsThreshold;
+    const triggeredByCentroid =
+      this.previousCentroid !== null && Math.abs(centroid - this.previousCentroid) >= centroidJump;
+
+    this.previousCentroid = centroid;
+
+    if (!triggeredByRms && !triggeredByCentroid) {
+      return;
+    }
+
+    if (ts - this.lastEventTs < minInterval) {
+      return;
+    }
+
+    this.lastEventTs = ts;
+
+    const payload: EventPayload = {
+      ts,
+      detector: 'audio-anomaly',
+      source: this.options.source,
+      severity: triggeredByRms ? 'critical' : 'warning',
+      message: triggeredByRms ? 'High audio level detected' : 'Abrupt spectral change detected',
+      meta: {
+        rms,
+        centroid,
+        rmsThreshold,
+        centroidJump,
+        triggeredBy: triggeredByRms ? 'rms' : 'centroid'
+      }
+    };
+
+    this.bus.emit('event', payload);
+  }
+}
+
+function normalizeSamples(samples: Int16Array): Float32Array {
+  const normalized = new Float32Array(samples.length);
+  const scale = 1 / 32768;
+  for (let i = 0; i < samples.length; i += 1) {
+    normalized[i] = samples[i] * scale;
+  }
+  return normalized;
+}
+
+export default AudioAnomalyDetector;

--- a/src/audio/source.ts
+++ b/src/audio/source.ts
@@ -1,0 +1,158 @@
+import { EventEmitter } from 'node:events';
+import { spawn, ChildProcessWithoutNullStreams } from 'node:child_process';
+import { Readable } from 'node:stream';
+import ffmpegStatic from 'ffmpeg-static';
+
+export type AudioSourceOptions =
+  | {
+      type: 'mic';
+      device?: string;
+      inputFormat?: 'alsa' | 'avfoundation' | 'dshow';
+      sampleRate?: number;
+      channels?: number;
+      frameDurationMs?: number;
+    }
+  | {
+      type: 'ffmpeg';
+      input: string;
+      sampleRate?: number;
+      channels?: number;
+      frameDurationMs?: number;
+      extraInputArgs?: string[];
+    };
+
+const DEFAULT_SAMPLE_RATE = 16000;
+const DEFAULT_CHANNELS = 1;
+const DEFAULT_FRAME_DURATION_MS = 100;
+
+export class AudioSource extends EventEmitter {
+  private process: ChildProcessWithoutNullStreams | null = null;
+  private buffer = Buffer.alloc(0);
+
+  constructor(private readonly options: AudioSourceOptions) {
+    super();
+  }
+
+  start() {
+    if (this.process) {
+      return;
+    }
+
+    const sampleRate = this.options.sampleRate ?? DEFAULT_SAMPLE_RATE;
+    const channels = this.options.channels ?? DEFAULT_CHANNELS;
+    const ffmpegPath = (ffmpegStatic as string | null) ?? 'ffmpeg';
+
+    const args = this.buildFfmpegArgs(sampleRate, channels);
+
+    this.process = spawn(ffmpegPath, args, {
+      stdio: this.options.type === 'ffmpeg' && this.options.input === 'pipe:0' ? ['pipe', 'pipe', 'pipe'] : ['ignore', 'pipe', 'pipe']
+    });
+
+    this.process.stdout.on('data', chunk => {
+      this.consumeChunk(chunk, sampleRate, channels);
+    });
+
+    this.process.stderr.on('data', chunk => {
+      this.emit('stderr', chunk.toString());
+    });
+
+    this.process.on('error', error => {
+      this.emit('error', error);
+    });
+
+    this.process.on('close', code => {
+      this.emit('close', code);
+      this.process = null;
+    });
+  }
+
+  stop() {
+    if (this.process) {
+      this.process.kill('SIGINT');
+      this.process = null;
+    }
+  }
+
+  consume(stream: Readable, sampleRate = DEFAULT_SAMPLE_RATE, channels = DEFAULT_CHANNELS) {
+    stream.on('data', chunk => {
+      this.consumeChunk(chunk, sampleRate, channels);
+    });
+  }
+
+  private consumeChunk(chunk: Buffer, sampleRate: number, channels: number) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    const frameSizeSamples = this.calculateFrameSize(sampleRate, channels);
+    const frameSizeBytes = frameSizeSamples * 2;
+
+    while (this.buffer.length >= frameSizeBytes) {
+      const frame = this.buffer.subarray(0, frameSizeBytes);
+      this.buffer = this.buffer.subarray(frameSizeBytes);
+      const samples = bufferToInt16(frame);
+      this.emit('data', samples);
+    }
+  }
+
+  private calculateFrameSize(sampleRate: number, channels: number) {
+    const frameDuration = this.options.frameDurationMs ?? DEFAULT_FRAME_DURATION_MS;
+    return Math.max(1, Math.floor((sampleRate * frameDuration) / 1000)) * channels;
+  }
+
+  private buildFfmpegArgs(sampleRate: number, channels: number) {
+    const outputArgs = [
+      '-ac',
+      String(channels),
+      '-ar',
+      String(sampleRate),
+      '-f',
+      's16le',
+      '-acodec',
+      'pcm_s16le',
+      'pipe:1'
+    ];
+
+    if (this.options.type === 'mic') {
+      const platform = process.platform;
+      const format = this.options.inputFormat ?? defaultMicFormat(platform);
+      const device = this.options.device ?? defaultMicDevice(platform);
+      const inputArgs: string[] = [];
+      if (format) {
+        inputArgs.push('-f', format);
+      }
+      inputArgs.push('-i', device);
+      return [...inputArgs, ...outputArgs];
+    }
+
+    const inputArgs = [...(this.options.extraInputArgs ?? []), '-i', this.options.input];
+    return [...inputArgs, ...outputArgs];
+  }
+}
+
+function bufferToInt16(buffer: Buffer): Int16Array {
+  const samples = new Int16Array(buffer.length / 2);
+  for (let i = 0; i < samples.length; i += 1) {
+    samples[i] = buffer.readInt16LE(i * 2);
+  }
+  return samples;
+}
+
+function defaultMicFormat(platform: NodeJS.Platform): AudioSourceOptions['inputFormat'] {
+  switch (platform) {
+    case 'darwin':
+      return 'avfoundation';
+    case 'win32':
+      return 'dshow';
+    default:
+      return 'alsa';
+  }
+}
+
+function defaultMicDevice(platform: NodeJS.Platform): string {
+  switch (platform) {
+    case 'darwin':
+      return ':0';
+    case 'win32':
+      return 'audio="default"';
+    default:
+      return 'default';
+  }
+}

--- a/src/run-audio-detector.ts
+++ b/src/run-audio-detector.ts
@@ -1,0 +1,50 @@
+import logger from './logger.js';
+import eventBus from './eventBus.js';
+import { AudioSource } from './audio/source.js';
+import AudioAnomalyDetector from './audio/anomaly.js';
+
+const source = new AudioSource({
+  type: 'mic',
+  frameDurationMs: 200,
+  sampleRate: 16000
+});
+
+const detector = new AudioAnomalyDetector({
+  source: 'audio:microphone',
+  sampleRate: 16000,
+  rmsThreshold: 0.25,
+  centroidJumpThreshold: 200,
+  minIntervalMs: 2000
+});
+
+logger.info('Starting audio anomaly detector');
+
+eventBus.on('event', payload => {
+  if (payload.detector === 'audio-anomaly') {
+    logger.info({ meta: payload.meta }, 'Audio anomaly detected');
+  }
+});
+
+source.on('data', samples => {
+  detector.handleChunk(samples);
+});
+
+source.on('error', error => {
+  logger.error({ err: error }, 'Audio source error');
+});
+
+source.on('stderr', data => {
+  logger.debug({ ffmpeg: data });
+});
+
+source.on('close', code => {
+  logger.warn({ code }, 'Audio source closed');
+});
+
+source.start();
+
+process.on('SIGINT', () => {
+  logger.info('Stopping audio detector');
+  source.stop();
+  process.exit(0);
+});

--- a/src/run-guard.ts
+++ b/src/run-guard.ts
@@ -1,0 +1,97 @@
+import config from 'config';
+import logger from './logger.js';
+import eventBus from './eventBus.js';
+import { ensureSampleVideo } from './video/sampleVideo.js';
+import { VideoSource } from './video/source.js';
+import MotionDetector from './video/motionDetector.js';
+import PersonDetector from './video/personDetector.js';
+
+const videoConfig = config.get<{ testFile: string; framesPerSecond: number }>('video');
+const personConfig = config.get<{
+  modelPath: string;
+  score: number;
+  checkEveryNFrames?: number;
+  maxDetections?: number;
+  snapshotDir?: string;
+}>('person');
+
+const videoFile = ensureSampleVideo(videoConfig.testFile);
+
+const source = new VideoSource({
+  file: videoFile,
+  framesPerSecond: videoConfig.framesPerSecond
+});
+
+const motionDetector = new MotionDetector({
+  source: 'video:test-camera',
+  diffThreshold: 25,
+  areaThreshold: 0.015,
+  minIntervalMs: 1500
+});
+
+const personDetector = await PersonDetector.create({
+  source: 'video:test-camera',
+  modelPath: personConfig.modelPath,
+  scoreThreshold: personConfig.score,
+  snapshotDir: personConfig.snapshotDir,
+  minIntervalMs: 2000
+});
+
+const checkEvery = Math.max(1, personConfig.checkEveryNFrames ?? 3);
+const maxDetections = Math.max(1, personConfig.maxDetections ?? 5);
+
+let framesSinceMotion: number | null = null;
+let detectionAttempts = 0;
+
+logger.info({ file: videoFile }, 'Starting guard pipeline');
+
+eventBus.on('event', payload => {
+  if (payload.detector === 'motion') {
+    framesSinceMotion = 0;
+    detectionAttempts = 0;
+  }
+});
+
+source.on('frame', async frame => {
+  const ts = Date.now();
+
+  try {
+    motionDetector.handleFrame(frame, ts);
+  } catch (error) {
+    logger.error({ err: error }, 'Motion detector failed');
+  }
+
+  if (framesSinceMotion !== null) {
+    framesSinceMotion += 1;
+    const shouldDetect = framesSinceMotion === 1 || framesSinceMotion % checkEvery === 0;
+
+    if (shouldDetect && detectionAttempts < maxDetections) {
+      detectionAttempts += 1;
+      try {
+        await personDetector.handleFrame(frame, ts);
+      } catch (error) {
+        logger.error({ err: error }, 'Person detector failed');
+      }
+    }
+
+    if (detectionAttempts >= maxDetections) {
+      framesSinceMotion = null;
+    }
+  }
+});
+
+source.on('error', error => {
+  logger.error({ err: error }, 'Video source error');
+});
+
+source.on('end', () => {
+  logger.warn('Video source ended');
+});
+
+source.start();
+
+process.on('SIGINT', () => {
+  logger.info('Stopping guard pipeline');
+  source.stop();
+  process.exit(0);
+});

--- a/src/run-video-detectors.ts
+++ b/src/run-video-detectors.ts
@@ -1,0 +1,59 @@
+import config from 'config';
+import logger from './logger.js';
+import eventBus from './eventBus.js';
+import { ensureSampleVideo } from './video/sampleVideo.js';
+import { VideoSource } from './video/source.js';
+import LightDetector from './video/lightDetector.js';
+import MotionDetector from './video/motionDetector.js';
+
+const videoConfig = config.get<{ testFile: string; framesPerSecond: number }>('video');
+const videoFile = ensureSampleVideo(videoConfig.testFile);
+
+const source = new VideoSource({
+  file: videoFile,
+  framesPerSecond: videoConfig.framesPerSecond
+});
+
+const motionDetector = new MotionDetector({
+  source: 'video:test-camera',
+  diffThreshold: 25,
+  areaThreshold: 0.015,
+  minIntervalMs: 1500
+});
+
+const lightDetector = new LightDetector({
+  source: 'video:test-camera',
+  deltaThreshold: 40,
+  normalHours: [
+    { start: 7, end: 22 }
+  ],
+  smoothingFactor: 0.1,
+  minIntervalMs: 30000
+});
+
+logger.info({ file: videoFile }, 'Starting video detectors');
+
+eventBus.on('event', payload => {
+  logger.info({ detector: payload.detector, meta: payload.meta }, 'Detector event');
+});
+
+source.on('frame', frame => {
+  motionDetector.handleFrame(frame);
+  lightDetector.handleFrame(frame);
+});
+
+source.on('error', error => {
+  logger.error({ err: error }, 'Video source error');
+});
+
+source.on('end', () => {
+  logger.warn('Video source ended');
+});
+
+source.start();
+
+process.on('SIGINT', () => {
+  logger.info('Stopping video detectors');
+  source.stop();
+  process.exit(0);
+});

--- a/src/video/lightDetector.ts
+++ b/src/video/lightDetector.ts
@@ -1,0 +1,102 @@
+import { EventEmitter } from 'node:events';
+import eventBus from '../eventBus.js';
+import { EventPayload } from '../types.js';
+import { averageLuminance, readFrameAsGrayscale } from './utils.js';
+
+export interface LightDetectorOptions {
+  source: string;
+  deltaThreshold?: number;
+  normalHours?: Array<{ start: number; end: number }>;
+  smoothingFactor?: number;
+  minIntervalMs?: number;
+}
+
+const DEFAULT_DELTA_THRESHOLD = 30;
+const DEFAULT_SMOOTHING = 0.2;
+const DEFAULT_MIN_INTERVAL_MS = 60000;
+
+export class LightDetector {
+  private baseline: number | null = null;
+  private lastEventTs = 0;
+
+  constructor(
+    private readonly options: LightDetectorOptions,
+    private readonly bus: EventEmitter = eventBus
+  ) {}
+
+  handleFrame(frame: Buffer, ts = Date.now()) {
+    const grayscale = readFrameAsGrayscale(frame);
+    const luminance = averageLuminance(grayscale);
+
+    if (this.baseline === null) {
+      this.baseline = luminance;
+      return;
+    }
+
+    const smoothing = this.options.smoothingFactor ?? DEFAULT_SMOOTHING;
+    this.baseline = this.baseline * (1 - smoothing) + luminance * smoothing;
+
+    if (this.isWithinNormalHours(ts)) {
+      return;
+    }
+
+    const deltaThreshold = this.options.deltaThreshold ?? DEFAULT_DELTA_THRESHOLD;
+    const delta = Math.abs(luminance - this.baseline);
+
+    if (delta < deltaThreshold) {
+      return;
+    }
+
+    if (ts - this.lastEventTs < (this.options.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS)) {
+      return;
+    }
+
+    this.lastEventTs = ts;
+
+    const payload: EventPayload = {
+      ts,
+      detector: 'light',
+      source: this.options.source,
+      severity: 'warning',
+      message: 'Unexpected light level change detected',
+      meta: {
+        baseline: this.baseline,
+        luminance,
+        delta,
+        deltaThreshold
+      }
+    };
+
+    this.bus.emit('event', payload);
+  }
+
+  private isWithinNormalHours(ts: number) {
+    const hours = this.options.normalHours;
+    if (!hours || hours.length === 0) {
+      return false;
+    }
+
+    const currentHour = new Date(ts).getHours();
+
+    return hours.some(range => isHourWithinRange(currentHour, range.start, range.end));
+  }
+}
+
+function isHourWithinRange(hour: number, start: number, end: number): boolean {
+  const normalizedStart = normalizeHour(start);
+  const normalizedEnd = normalizeHour(end);
+  const normalizedHour = normalizeHour(hour);
+
+  if (normalizedStart <= normalizedEnd) {
+    return normalizedHour >= normalizedStart && normalizedHour < normalizedEnd;
+  }
+
+  // Overnight window (e.g. 22-6)
+  return normalizedHour >= normalizedStart || normalizedHour < normalizedEnd;
+}
+
+function normalizeHour(hour: number) {
+  return ((Math.floor(hour) % 24) + 24) % 24;
+}
+
+export default LightDetector;

--- a/src/video/motionDetector.ts
+++ b/src/video/motionDetector.ts
@@ -1,0 +1,68 @@
+import { EventEmitter } from 'node:events';
+import eventBus from '../eventBus.js';
+import { EventPayload } from '../types.js';
+import { diffAreaPercentage, readFrameAsGrayscale, GrayscaleFrame } from './utils.js';
+
+export interface MotionDetectorOptions {
+  source: string;
+  diffThreshold?: number;
+  areaThreshold?: number;
+  minIntervalMs?: number;
+}
+
+const DEFAULT_DIFF_THRESHOLD = 25;
+const DEFAULT_AREA_THRESHOLD = 0.02;
+const DEFAULT_MIN_INTERVAL_MS = 2000;
+
+export class MotionDetector {
+  private previousFrame: GrayscaleFrame | null = null;
+  private lastEventTs = 0;
+
+  constructor(
+    private readonly options: MotionDetectorOptions,
+    private readonly bus: EventEmitter = eventBus
+  ) {}
+
+  handleFrame(frame: Buffer, ts = Date.now()) {
+    const grayscale = readFrameAsGrayscale(frame);
+
+    if (!this.previousFrame) {
+      this.previousFrame = grayscale;
+      return;
+    }
+
+    const diffThreshold = this.options.diffThreshold ?? DEFAULT_DIFF_THRESHOLD;
+    const areaThreshold = this.options.areaThreshold ?? DEFAULT_AREA_THRESHOLD;
+
+    const areaPct = diffAreaPercentage(this.previousFrame, grayscale, diffThreshold);
+
+    this.previousFrame = grayscale;
+
+    if (areaPct < areaThreshold) {
+      return;
+    }
+
+    if (ts - this.lastEventTs < (this.options.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS)) {
+      return;
+    }
+
+    this.lastEventTs = ts;
+
+    const payload: EventPayload = {
+      ts,
+      detector: 'motion',
+      source: this.options.source,
+      severity: 'warning',
+      message: 'Motion detected',
+      meta: {
+        areaPct,
+        areaThreshold,
+        diffThreshold
+      }
+    };
+
+    this.bus.emit('event', payload);
+  }
+}
+
+export default MotionDetector;

--- a/src/video/personDetector.ts
+++ b/src/video/personDetector.ts
@@ -1,0 +1,259 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { EventEmitter } from 'node:events';
+import { PNG } from 'pngjs';
+import * as ort from 'onnxruntime-node';
+import eventBus from '../eventBus.js';
+import { EventPayload } from '../types.js';
+
+export interface PersonDetectorOptions {
+  source: string;
+  modelPath: string;
+  scoreThreshold?: number;
+  snapshotDir?: string;
+  minIntervalMs?: number;
+}
+
+type PreprocessMeta = {
+  scale: number;
+  padX: number;
+  padY: number;
+  originalWidth: number;
+  originalHeight: number;
+};
+
+type Detection = {
+  score: number;
+  bbox: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  };
+};
+
+const TARGET_SIZE = 640;
+const PERSON_CLASS_INDEX = 4;
+const DEFAULT_SCORE_THRESHOLD = 0.5;
+const DEFAULT_MIN_INTERVAL_MS = 5000;
+
+export class PersonDetector {
+  private session: ort.InferenceSession | null = null;
+  private inputName: string | null = null;
+  private outputName: string | null = null;
+  private lastEventTs = 0;
+
+  private constructor(
+    private readonly options: PersonDetectorOptions,
+    private readonly bus: EventEmitter
+  ) {}
+
+  static async create(options: PersonDetectorOptions, bus: EventEmitter = eventBus) {
+    const detector = new PersonDetector(options, bus);
+    await detector.ensureSession();
+    return detector;
+  }
+
+  async handleFrame(frame: Buffer, ts = Date.now()) {
+    await this.ensureSession();
+
+    if (!this.session || !this.inputName || !this.outputName) {
+      return;
+    }
+
+    if (ts - this.lastEventTs < (this.options.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS)) {
+      return;
+    }
+
+    const { tensor, meta } = preprocessFrame(frame);
+    const feeds: Record<string, ort.Tensor> = {
+      [this.inputName]: tensor
+    };
+
+    const results = await this.session.run(feeds);
+    const output = results[this.outputName];
+
+    if (!output) {
+      return;
+    }
+
+    const detection = pickBestPerson(
+      output,
+      this.options.scoreThreshold ?? DEFAULT_SCORE_THRESHOLD,
+      meta
+    );
+
+    if (!detection) {
+      return;
+    }
+
+    const snapshotPath = saveSnapshot(frame, ts, this.options.snapshotDir);
+    this.lastEventTs = ts;
+
+    const payload: EventPayload = {
+      ts,
+      source: this.options.source,
+      detector: 'person',
+      severity: 'critical',
+      message: 'Person detected',
+      meta: {
+        score: detection.score,
+        bbox: detection.bbox,
+        snapshot: snapshotPath
+      }
+    };
+
+    this.bus.emit('event', payload);
+  }
+
+  private async ensureSession() {
+    if (this.session) {
+      return;
+    }
+
+    const session = await ort.InferenceSession.create(this.options.modelPath);
+    this.session = session;
+    this.inputName = session.inputNames[0] ?? null;
+    this.outputName = session.outputNames[0] ?? null;
+  }
+}
+
+function preprocessFrame(frame: Buffer): { tensor: ort.Tensor; meta: PreprocessMeta } {
+  const image = PNG.sync.read(frame);
+  const { width, height, data } = image;
+
+  const scale = Math.min(TARGET_SIZE / width, TARGET_SIZE / height);
+  const resizedWidth = Math.round(width * scale);
+  const resizedHeight = Math.round(height * scale);
+  const padX = Math.floor((TARGET_SIZE - resizedWidth) / 2);
+  const padY = Math.floor((TARGET_SIZE - resizedHeight) / 2);
+
+  const pixels = TARGET_SIZE * TARGET_SIZE;
+  const chw = new Float32Array(3 * pixels).fill(0);
+
+  for (let y = 0; y < resizedHeight; y += 1) {
+    const srcY = Math.min(height - 1, Math.floor(y / scale));
+    for (let x = 0; x < resizedWidth; x += 1) {
+      const srcX = Math.min(width - 1, Math.floor(x / scale));
+      const destX = x + padX;
+      const destY = y + padY;
+      const destIndex = destY * TARGET_SIZE + destX;
+      const srcIndex = (srcY * width + srcX) * 4;
+
+      const r = data[srcIndex] / 255;
+      const g = data[srcIndex + 1] / 255;
+      const b = data[srcIndex + 2] / 255;
+
+      chw[destIndex] = r;
+      chw[pixels + destIndex] = g;
+      chw[2 * pixels + destIndex] = b;
+    }
+  }
+
+  const tensor = new ort.Tensor('float32', chw, [1, 3, TARGET_SIZE, TARGET_SIZE]);
+
+  return {
+    tensor,
+    meta: {
+      scale,
+      padX,
+      padY,
+      originalWidth: width,
+      originalHeight: height
+    }
+  };
+}
+
+function pickBestPerson(
+  tensor: ort.OnnxValue,
+  threshold: number,
+  meta: PreprocessMeta
+): Detection | null {
+  const data = tensor.data as Float32Array | undefined;
+  const dims = tensor.dims ?? [];
+
+  if (!data || dims.length < 3) {
+    return null;
+  }
+
+  const numDetections = dims[dims.length - 1];
+  const numChannels = dims[dims.length - 2];
+
+  if (numChannels <= PERSON_CLASS_INDEX) {
+    return null;
+  }
+
+  const stride = numDetections;
+  let best: Detection | null = null;
+
+  for (let i = 0; i < numDetections; i += 1) {
+    const score = data[PERSON_CLASS_INDEX * stride + i];
+
+    if (score < threshold) {
+      continue;
+    }
+
+    const cx = data[0 * stride + i];
+    const cy = data[1 * stride + i];
+    const w = data[2 * stride + i];
+    const h = data[3 * stride + i];
+
+    const bbox = projectBoundingBox(cx, cy, w, h, meta);
+
+    if (bbox.width <= 0 || bbox.height <= 0) {
+      continue;
+    }
+
+    if (!best || score > best.score) {
+      best = { score, bbox };
+    }
+  }
+
+  return best;
+}
+
+function projectBoundingBox(
+  cx: number,
+  cy: number,
+  width: number,
+  height: number,
+  meta: PreprocessMeta
+) {
+  const left = cx - width / 2;
+  const top = cy - height / 2;
+  const right = cx + width / 2;
+  const bottom = cy + height / 2;
+
+  const scale = meta.scale || 1;
+
+  const mappedLeft = (left - meta.padX) / scale;
+  const mappedTop = (top - meta.padY) / scale;
+  const mappedRight = (right - meta.padX) / scale;
+  const mappedBottom = (bottom - meta.padY) / scale;
+
+  const clampedLeft = clamp(mappedLeft, 0, meta.originalWidth);
+  const clampedTop = clamp(mappedTop, 0, meta.originalHeight);
+  const clampedRight = clamp(mappedRight, 0, meta.originalWidth);
+  const clampedBottom = clamp(mappedBottom, 0, meta.originalHeight);
+
+  return {
+    left: clampedLeft,
+    top: clampedTop,
+    width: Math.max(0, clampedRight - clampedLeft),
+    height: Math.max(0, clampedBottom - clampedTop)
+  };
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function saveSnapshot(frame: Buffer, ts: number, dir?: string) {
+  const folder = path.resolve(dir ?? 'snapshots');
+  fs.mkdirSync(folder, { recursive: true });
+  const filePath = path.join(folder, `${ts}-person.png`);
+  fs.writeFileSync(filePath, frame);
+  return filePath;
+}
+
+export default PersonDetector;

--- a/src/video/utils.ts
+++ b/src/video/utils.ts
@@ -1,0 +1,57 @@
+import { PNG } from 'pngjs';
+
+export type GrayscaleFrame = {
+  width: number;
+  height: number;
+  data: Uint8Array;
+};
+
+export function readFrameAsGrayscale(pngBuffer: Buffer): GrayscaleFrame {
+  const image = PNG.sync.read(pngBuffer);
+  const { width, height, data } = image;
+  const grayscale = new Uint8Array(width * height);
+
+  for (let i = 0; i < width * height; i += 1) {
+    const offset = i * 4;
+    const r = data[offset];
+    const g = data[offset + 1];
+    const b = data[offset + 2];
+    // Rec. 709 luma coefficients
+    grayscale[i] = Math.round(0.2126 * r + 0.7152 * g + 0.0722 * b);
+  }
+
+  return { width, height, data: grayscale };
+}
+
+export function averageLuminance(frame: GrayscaleFrame): number {
+  let total = 0;
+  const { data } = frame;
+
+  for (let i = 0; i < data.length; i += 1) {
+    total += data[i];
+  }
+
+  return total / data.length;
+}
+
+export function diffAreaPercentage(
+  previous: GrayscaleFrame,
+  current: GrayscaleFrame,
+  threshold: number
+): number {
+  if (previous.width !== current.width || previous.height !== current.height) {
+    throw new Error('Frame dimensions must match for diff comparison');
+  }
+
+  const totalPixels = current.data.length;
+  let changedPixels = 0;
+
+  for (let i = 0; i < totalPixels; i += 1) {
+    const delta = Math.abs(current.data[i] - previous.data[i]);
+    if (delta >= threshold) {
+      changedPixels += 1;
+    }
+  }
+
+  return changedPixels / totalPixels;
+}

--- a/tests/audio_anomaly.test.ts
+++ b/tests/audio_anomaly.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import AudioAnomalyDetector from '../src/audio/anomaly.js';
+
+interface CapturedEvent {
+  detector: string;
+  meta?: Record<string, unknown>;
+}
+
+describe('AudioAnomalyDetector', () => {
+  const sampleRate = 16000;
+  let bus: EventEmitter;
+  let events: CapturedEvent[];
+
+  beforeEach(() => {
+    bus = new EventEmitter();
+    events = [];
+    bus.on('event', payload => {
+      events.push({ detector: payload.detector, meta: payload.meta });
+    });
+  });
+
+  it('emits event when RMS exceeds threshold', () => {
+    const detector = new AudioAnomalyDetector(
+      {
+        source: 'audio:test',
+        sampleRate,
+        rmsThreshold: 0.1,
+        centroidJumpThreshold: 2000,
+        minIntervalMs: 0
+      },
+      bus
+    );
+
+    const silence = new Int16Array(1024);
+    const loud = new Int16Array(1024).map((_, i) => (i % 2 === 0 ? 16000 : -16000));
+
+    detector.handleChunk(silence, 0);
+    detector.handleChunk(loud, 1);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].detector).toBe('audio-anomaly');
+    expect(events[0].meta?.triggeredBy).toBe('rms');
+  });
+
+  it('emits event on sharp spectral centroid change', () => {
+    const detector = new AudioAnomalyDetector(
+      {
+        source: 'audio:test',
+        sampleRate,
+        rmsThreshold: 0.5,
+        centroidJumpThreshold: 50,
+        minIntervalMs: 0
+      },
+      bus
+    );
+
+    const toneLow = generateSineWave(sampleRate, 200, 0.2, 1024);
+    const toneHigh = generateSineWave(sampleRate, 3000, 0.2, 1024);
+
+    detector.handleChunk(toneLow, 0);
+    detector.handleChunk(toneHigh, 1);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].meta?.triggeredBy).toBe('centroid');
+  });
+});
+
+function generateSineWave(sampleRate: number, frequency: number, amplitude: number, length: number) {
+  const result = new Int16Array(length);
+  for (let i = 0; i < length; i += 1) {
+    const value = Math.sin((2 * Math.PI * frequency * i) / sampleRate) * amplitude;
+    result[i] = Math.round(value * 32767);
+  }
+  return result;
+}

--- a/tests/motion_light.test.ts
+++ b/tests/motion_light.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PNG } from 'pngjs';
+import MotionDetector from '../src/video/motionDetector.js';
+import LightDetector from '../src/video/lightDetector.js';
+
+interface CapturedEvent {
+  detector: string;
+  meta?: Record<string, unknown>;
+}
+
+describe('MotionDetector', () => {
+  let bus: EventEmitter;
+  let events: CapturedEvent[];
+
+  beforeEach(() => {
+    bus = new EventEmitter();
+    events = [];
+    bus.on('event', payload => {
+      events.push({ detector: payload.detector, meta: payload.meta });
+    });
+  });
+
+  it('ignores small changes below area threshold', () => {
+    const detector = new MotionDetector(
+      {
+        source: 'test-camera',
+        diffThreshold: 20,
+        areaThreshold: 0.2,
+        minIntervalMs: 0
+      },
+      bus
+    );
+
+    const base = createUniformFrame(16, 16, 10);
+    const slightlyChanged = createFrame(16, 16, (x, y) => (x < 4 && y < 4 ? 50 : 10));
+
+    detector.handleFrame(base, 0);
+    detector.handleFrame(slightlyChanged, 1);
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('emits event when changed area exceeds threshold', () => {
+    const detector = new MotionDetector(
+      {
+        source: 'test-camera',
+        diffThreshold: 10,
+        areaThreshold: 0.1,
+        minIntervalMs: 0
+      },
+      bus
+    );
+
+    const base = createUniformFrame(10, 10, 10);
+    const changed = createFrame(10, 10, (x, y) => (x < 5 ? 200 : 10));
+
+    detector.handleFrame(base, 0);
+    detector.handleFrame(changed, 1);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].detector).toBe('motion');
+    expect(events[0].meta?.areaPct).toBeGreaterThan(0.4);
+  });
+});
+
+describe('LightDetector', () => {
+  let bus: EventEmitter;
+  let events: CapturedEvent[];
+
+  beforeEach(() => {
+    bus = new EventEmitter();
+    events = [];
+    bus.on('event', payload => {
+      events.push({ detector: payload.detector, meta: payload.meta });
+    });
+  });
+
+  it('detects sharp luminance changes outside normal hours', () => {
+    const detector = new LightDetector(
+      {
+        source: 'test-camera',
+        deltaThreshold: 20,
+        normalHours: [{ start: 8, end: 20 }],
+        smoothingFactor: 0,
+        minIntervalMs: 0
+      },
+      bus
+    );
+
+    const dark = createUniformFrame(8, 8, 5);
+    const bright = createUniformFrame(8, 8, 200);
+
+    const ts1 = new Date('2024-01-01T06:00:00Z').getTime();
+    const ts2 = new Date('2024-01-01T06:05:00Z').getTime();
+
+    detector.handleFrame(dark, ts1);
+    detector.handleFrame(bright, ts2);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].detector).toBe('light');
+    expect(events[0].meta?.delta).toBeGreaterThan(150);
+  });
+
+  it('ignores changes during configured normal hours', () => {
+    const detector = new LightDetector(
+      {
+        source: 'test-camera',
+        deltaThreshold: 10,
+        normalHours: [{ start: 7, end: 22 }],
+        smoothingFactor: 0,
+        minIntervalMs: 0
+      },
+      bus
+    );
+
+    const base = createUniformFrame(8, 8, 120);
+    const brighter = createUniformFrame(8, 8, 180);
+
+    const ts1 = new Date('2024-01-01T12:00:00Z').getTime();
+    const ts2 = new Date('2024-01-01T12:01:00Z').getTime();
+
+    detector.handleFrame(base, ts1);
+    detector.handleFrame(brighter, ts2);
+
+    expect(events).toHaveLength(0);
+  });
+});
+
+function createUniformFrame(width: number, height: number, value: number) {
+  return createFrame(width, height, () => value);
+}
+
+function createFrame(width: number, height: number, fn: (x: number, y: number) => number) {
+  const png = new PNG({ width, height });
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const idx = (width * y + x) << 2;
+      const value = clamp(fn(x, y));
+      png.data[idx] = value;
+      png.data[idx + 1] = value;
+      png.data[idx + 2] = value;
+      png.data[idx + 3] = 255;
+    }
+  }
+  return PNG.sync.write(png);
+}
+
+function clamp(value: number) {
+  return Math.max(0, Math.min(255, Math.round(value)));
+}

--- a/tests/person_detector.test.ts
+++ b/tests/person_detector.test.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { EventEmitter } from 'node:events';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { PNG } from 'pngjs';
+import PersonDetector from '../src/video/personDetector.js';
+
+const runMock = vi.fn();
+
+vi.mock('onnxruntime-node', () => {
+  class Tensor<T> {
+    constructor(
+      public readonly type: string,
+      public readonly data: T,
+      public readonly dims: number[]
+    ) {}
+  }
+
+  return {
+    InferenceSession: {
+      create: vi.fn(async () => ({
+        inputNames: ['images'],
+        outputNames: ['output0'],
+        run: runMock
+      }))
+    },
+    Tensor
+  };
+});
+
+describe('PersonDetector', () => {
+  const snapshotsDir = path.resolve('snapshots');
+  let bus: EventEmitter;
+  let events: { detector: string; meta?: Record<string, unknown> }[];
+
+  beforeEach(() => {
+    if (fs.existsSync(snapshotsDir)) {
+      fs.rmSync(snapshotsDir, { recursive: true, force: true });
+    }
+
+    bus = new EventEmitter();
+    events = [];
+    bus.on('event', payload => {
+      events.push({ detector: payload.detector, meta: payload.meta });
+    });
+
+    runMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(snapshotsDir)) {
+      fs.rmSync(snapshotsDir, { recursive: true, force: true });
+    }
+  });
+
+  it('emits event and saves snapshot when person score passes threshold', async () => {
+    const detectionData = new Float32Array(84);
+    detectionData[0] = 320;
+    detectionData[1] = 320;
+    detectionData[2] = 200;
+    detectionData[3] = 200;
+    detectionData[4] = 0.9;
+
+    runMock.mockResolvedValue({
+      output0: {
+        data: detectionData,
+        dims: [1, 84, 1]
+      }
+    });
+
+    const detector = await PersonDetector.create(
+      {
+        source: 'video:test-camera',
+        modelPath: 'models/yolov8n.onnx',
+        scoreThreshold: 0.5,
+        snapshotDir: 'snapshots',
+        minIntervalMs: 0
+      },
+      bus
+    );
+
+    const frame = createUniformFrame(640, 640, 25);
+    const ts = 1234567890;
+
+    await detector.handleFrame(frame, ts);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].detector).toBe('person');
+    expect(events[0].meta?.score).toBeCloseTo(0.9, 5);
+
+    const bbox = events[0].meta?.bbox as { left: number; top: number; width: number; height: number };
+    expect(bbox.left).toBeCloseTo(220, 0);
+    expect(bbox.top).toBeCloseTo(220, 0);
+    expect(bbox.width).toBeCloseTo(200, 0);
+    expect(bbox.height).toBeCloseTo(200, 0);
+
+    const snapshotPath = path.resolve('snapshots', `${ts}-person.png`);
+    expect(fs.existsSync(snapshotPath)).toBe(true);
+  });
+});
+
+function createUniformFrame(width: number, height: number, value: number) {
+  const png = new PNG({ width, height });
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const idx = (width * y + x) << 2;
+      png.data[idx] = value;
+      png.data[idx + 1] = value;
+      png.data[idx + 2] = value;
+      png.data[idx + 3] = 255;
+    }
+  }
+  return PNG.sync.write(png);
+}


### PR DESCRIPTION
## Summary
- add motion and light video detectors with shared grayscale utilities and a runner script
- add microphone/ffmpeg audio source plus Meyda-powered audio anomaly detector and CLI runner
- document detector parameters and add Vitest suites that validate motion/light frame thresholds and audio anomaly scenarios using synthetic data
- integrate an onnxruntime-backed PersonDetector that saves snapshots when motion triggers person scores above the configured threshold, with guard runner wiring and docs

## Testing
- pnpm vitest run -t "(Motion|Light)Detector"
- pnpm vitest run -t AudioAnomaly
- pnpm vitest run -t PersonDetector

------
https://chatgpt.com/codex/tasks/task_b_68d3c4b3abd48328b8bf3b2af66c0106