### PR TITLE
Add multi-camera guard pipeline and resilient audio source

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -17,13 +17,24 @@
   },
   "video": {
     "testFile": "assets/test-video.mp4",
-    "framesPerSecond": 2
+    "framesPerSecond": 2,
+    "cameras": [
+      {
+        "id": "test-camera",
+        "channel": "video:test-camera",
+        "input": "assets/test-video.mp4",
+        "person": {
+          "score": 0.5
+        }
+      }
+    ]
   },
   "person": {
     "modelPath": "models/yolov8n.onnx",
     "score": 0.5,
     "checkEveryNFrames": 3,
     "maxDetections": 5,
-    "snapshotDir": "snapshots"
+    "snapshotDir": "snapshots",
+    "minIntervalMs": 2000
   }
 }

--- a/src/audio/source.ts
+++ b/src/audio/source.ts
@@ -1,5 +1,10 @@
 import { EventEmitter } from 'node:events';
-import { spawn, ChildProcessWithoutNullStreams } from 'node:child_process';
+import {
+  spawn,
+  execFile,
+  ChildProcessWithoutNullStreams,
+  ExecFileException
+} from 'node:child_process';
 import { Readable } from 'node:stream';
 import ffmpegStatic from 'ffmpeg-static';
 
@@ -11,6 +16,7 @@ export type AudioSourceOptions =
       sampleRate?: number;
       channels?: number;
       frameDurationMs?: number;
+      retryDelayMs?: number;
     }
   | {
       type: 'ffmpeg';
@@ -19,64 +25,237 @@ export type AudioSourceOptions =
       channels?: number;
       frameDurationMs?: number;
       extraInputArgs?: string[];
+      retryDelayMs?: number;
     };
+
+export type AudioRecoverEvent = {
+  reason: 'ffmpeg-missing' | 'spawn-error' | 'process-exit';
+  attempt: number;
+  delayMs: number;
+  error?: Error;
+};
 
 const DEFAULT_SAMPLE_RATE = 16000;
 const DEFAULT_CHANNELS = 1;
 const DEFAULT_FRAME_DURATION_MS = 100;
+const DEFAULT_RETRY_DELAY_MS = 3000;
+
+const FFMPEG_CANDIDATES = buildFfmpegCandidates();
+const FFPROBE_CANDIDATES = buildFfprobeCandidates();
 
 export class AudioSource extends EventEmitter {
   private process: ChildProcessWithoutNullStreams | null = null;
+  private processCleanup: (() => void) | null = null;
   private buffer = Buffer.alloc(0);
+  private retryTimer: NodeJS.Timeout | null = null;
+  private retryCount = 0;
+  private shouldStop = false;
+  private currentBinaryIndex = 0;
+  private lastSuccessfulIndex = 0;
 
   constructor(private readonly options: AudioSourceOptions) {
     super();
   }
 
   start() {
-    if (this.process) {
+    if (this.process || this.retryTimer) {
       return;
     }
 
-    const sampleRate = this.options.sampleRate ?? DEFAULT_SAMPLE_RATE;
-    const channels = this.options.channels ?? DEFAULT_CHANNELS;
-    const ffmpegPath = (ffmpegStatic as string | null) ?? 'ffmpeg';
-
-    const args = this.buildFfmpegArgs(sampleRate, channels);
-
-    this.process = spawn(ffmpegPath, args, {
-      stdio: this.options.type === 'ffmpeg' && this.options.input === 'pipe:0' ? ['pipe', 'pipe', 'pipe'] : ['ignore', 'pipe', 'pipe']
-    });
-
-    this.process.stdout.on('data', chunk => {
-      this.consumeChunk(chunk, sampleRate, channels);
-    });
-
-    this.process.stderr.on('data', chunk => {
-      this.emit('stderr', chunk.toString());
-    });
-
-    this.process.on('error', error => {
-      this.emit('error', error);
-    });
-
-    this.process.on('close', code => {
-      this.emit('close', code);
-      this.process = null;
-    });
+    this.shouldStop = false;
+    this.retryCount = 0;
+    this.currentBinaryIndex = this.lastSuccessfulIndex;
+    this.startProcess();
   }
 
   stop() {
-    if (this.process) {
-      this.process.kill('SIGINT');
-      this.process = null;
-    }
+    this.shouldStop = true;
+    this.clearRetryTimer();
+    this.tearDownProcess();
   }
 
   consume(stream: Readable, sampleRate = DEFAULT_SAMPLE_RATE, channels = DEFAULT_CHANNELS) {
     stream.on('data', chunk => {
       this.consumeChunk(chunk, sampleRate, channels);
     });
+  }
+
+  static async listDevices(format: 'alsa' | 'avfoundation' | 'dshow') {
+    const args = ['-hide_banner', '-loglevel', 'info', '-f', format, '-list_devices', 'true', '-i', 'dummy'];
+
+    let lastError: Error | null = null;
+
+    for (const command of FFPROBE_CANDIDATES) {
+      try {
+        const { stdout, stderr } = await execFileAsync(command, args);
+        const parsed = parseDeviceList(`${stdout}\n${stderr}`);
+        return parsed;
+      } catch (error) {
+        lastError = error as Error;
+      }
+    }
+
+    throw lastError ?? new Error('Unable to list audio devices');
+  }
+
+  private startProcess() {
+    if (this.shouldStop) {
+      return;
+    }
+
+    const sampleRate = this.options.sampleRate ?? DEFAULT_SAMPLE_RATE;
+    const channels = this.options.channels ?? DEFAULT_CHANNELS;
+    const args = this.buildFfmpegArgs(sampleRate, channels);
+
+    let attemptIndex = this.currentBinaryIndex;
+
+    while (attemptIndex < FFMPEG_CANDIDATES.length) {
+      const binary = FFMPEG_CANDIDATES[attemptIndex];
+      try {
+        const stdio =
+          this.options.type === 'ffmpeg' && this.options.input === 'pipe:0'
+            ? ['pipe', 'pipe', 'pipe']
+            : ['ignore', 'pipe', 'pipe'];
+
+        const proc = spawn(binary, args, { stdio });
+
+        this.attachProcess(proc, sampleRate, channels, attemptIndex);
+        return;
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code === 'ENOENT') {
+          attemptIndex += 1;
+          continue;
+        }
+
+        this.emit('error', err);
+        this.scheduleRetry('spawn-error', err);
+        return;
+      }
+    }
+
+    this.currentBinaryIndex = 0;
+    const missingError = new Error('ffmpeg not found');
+    this.emit('error', missingError);
+    this.scheduleRetry('ffmpeg-missing', missingError);
+  }
+
+  private attachProcess(
+    proc: ChildProcessWithoutNullStreams,
+    sampleRate: number,
+    channels: number,
+    binaryIndex: number
+  ) {
+    this.teardownListeners();
+    this.process = proc;
+    this.currentBinaryIndex = binaryIndex;
+    this.lastSuccessfulIndex = binaryIndex;
+
+    const onStdout = (chunk: Buffer) => {
+      this.consumeChunk(chunk, sampleRate, channels);
+    };
+
+    const onStderr = (chunk: Buffer) => {
+      this.emit('stderr', chunk.toString());
+    };
+
+    proc.stdout.on('data', onStdout);
+    proc.stderr.on('data', onStderr);
+
+    const onError = (error: NodeJS.ErrnoException) => {
+      this.emit('error', error);
+      this.teardownListeners();
+
+      if (this.shouldStop) {
+        return;
+      }
+
+      if (error.code === 'ENOENT') {
+        this.currentBinaryIndex = binaryIndex + 1;
+        if (this.currentBinaryIndex >= FFMPEG_CANDIDATES.length) {
+          this.currentBinaryIndex = 0;
+        }
+        this.scheduleRetry('ffmpeg-missing', error);
+        return;
+      }
+
+      this.scheduleRetry('spawn-error', error);
+    };
+
+    const onClose = (code: number | null) => {
+      this.emit('close', code);
+      this.teardownListeners();
+
+      if (this.shouldStop) {
+        return;
+      }
+
+      this.currentBinaryIndex = this.lastSuccessfulIndex;
+      this.scheduleRetry('process-exit');
+    };
+
+    proc.once('error', onError);
+    proc.once('close', onClose);
+
+    this.processCleanup = () => {
+      proc.stdout.off('data', onStdout);
+      proc.stderr.off('data', onStderr);
+      proc.off('error', onError);
+      proc.off('close', onClose);
+      if (!proc.killed) {
+        try {
+          proc.kill('SIGINT');
+        } catch (error) {
+          // Ignore termination errors
+        }
+      }
+      proc.stdout.destroy();
+      proc.stderr.destroy();
+    };
+  }
+
+  private scheduleRetry(reason: AudioRecoverEvent['reason'], error?: Error) {
+    if (this.shouldStop) {
+      return;
+    }
+
+    this.clearRetryTimer();
+    this.retryCount += 1;
+    const delay = this.options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      this.startProcess();
+    }, delay);
+
+    this.emit('recover', {
+      reason,
+      attempt: this.retryCount,
+      delayMs: delay,
+      error
+    } as AudioRecoverEvent);
+  }
+
+  private teardownListeners() {
+    if (!this.process) {
+      return;
+    }
+
+    this.processCleanup?.();
+    this.processCleanup = null;
+    this.process = null;
+    this.buffer = Buffer.alloc(0);
+  }
+
+  private tearDownProcess() {
+    this.teardownListeners();
+  }
+
+  private clearRetryTimer() {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
   }
 
   private consumeChunk(chunk: Buffer, sampleRate: number, channels: number) {
@@ -156,3 +335,66 @@ function defaultMicDevice(platform: NodeJS.Platform): string {
       return 'default';
   }
 }
+
+function buildFfmpegCandidates() {
+  const candidates = new Set<string>();
+  if (typeof ffmpegStatic === 'string' && ffmpegStatic.length > 0) {
+    candidates.add(ffmpegStatic);
+  }
+  candidates.add('ffmpeg');
+  candidates.add('avconv');
+  return Array.from(candidates);
+}
+
+function buildFfprobeCandidates() {
+  const candidates = new Set<string>();
+  if (process.env.FFPROBE_PATH) {
+    candidates.add(process.env.FFPROBE_PATH);
+  }
+  candidates.add('ffprobe');
+  candidates.add('ffmpeg');
+  return Array.from(candidates);
+}
+
+function execFileAsync(command: string, args: string[]) {
+  return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+    execFile(command, args, (error: ExecFileException | null, stdout: string, stderr: string) => {
+      if (error) {
+        const err = error as ExecFileException & { stdout?: string; stderr?: string };
+        err.stdout = stdout;
+        err.stderr = stderr;
+        reject(err);
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+function parseDeviceList(output: string) {
+  const devices = new Set<string>();
+  const lines = output.split(/\r?\n/);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (!trimmed || trimmed.endsWith(':')) {
+      continue;
+    }
+
+    const quoted = trimmed.match(/"([^"]+)"/);
+    if (quoted) {
+      devices.add(quoted[1]);
+      continue;
+    }
+
+    const indexed = trimmed.match(/\[[0-9]+\]\s+(.+)/);
+    if (indexed) {
+      devices.add(indexed[1]);
+    }
+  }
+
+  return Array.from(devices);
+}
+
+export default AudioSource;

--- a/src/run-audio-detector.ts
+++ b/src/run-audio-detector.ts
@@ -33,6 +33,20 @@ source.on('error', error => {
   logger.error({ err: error }, 'Audio source error');
 });
 
+source.on('recover', event => {
+  if (event.reason === 'ffmpeg-missing') {
+    logger.warn(
+      { attempt: event.attempt, delayMs: event.delayMs },
+      `ffmpeg missing, retrying in ${event.delayMs}ms`
+    );
+  } else {
+    logger.warn(
+      { attempt: event.attempt, delayMs: event.delayMs, reason: event.reason },
+      `Audio source recovering, retrying in ${event.delayMs}ms`
+    );
+  }
+});
+
 source.on('stderr', data => {
   logger.debug({ ffmpeg: data });
 });

--- a/tests/audio_source.test.ts
+++ b/tests/audio_source.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ChildProcess, ExecFileCallback } from 'node:child_process';
+
+const spawnMock = vi.fn();
+const execFileMock = vi.fn();
+
+vi.mock('ffmpeg-static', () => ({
+  default: null
+}));
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    spawn: spawnMock,
+    execFile: execFileMock
+  };
+});
+
+describe('AudioSource resilience', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    spawnMock.mockReset();
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('AudioSourceFallback retries when ffmpeg is missing', async () => {
+    const { AudioSource } = await import('../src/audio/source.js');
+
+    spawnMock.mockImplementation(() => {
+      const error = new Error('not found') as NodeJS.ErrnoException;
+      error.code = 'ENOENT';
+      throw error;
+    });
+
+    const source = new AudioSource({ type: 'ffmpeg', input: 'pipe:0', retryDelayMs: 500 });
+    const recoverSpy = vi.fn();
+    const errorSpy = vi.fn();
+    source.on('recover', recoverSpy);
+    source.on('error', errorSpy);
+
+    source.start();
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(recoverSpy).toHaveBeenCalledTimes(1);
+    expect(recoverSpy.mock.calls[0][0].reason).toBe('ffmpeg-missing');
+    expect(errorSpy).toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+    expect(spawnMock).toHaveBeenCalledTimes(4);
+
+    source.stop();
+  });
+
+  it('AudioSourceFallback parses device list output', async () => {
+    const { AudioSource } = await import('../src/audio/source.js');
+
+    const output = `
+[dshow @ 000002] DirectShow audio devices
+[dshow @ 000002]  "Microphone (USB)"
+[dshow @ 000002]  "Line In (High Definition)"
+`;
+
+    execFileMock.mockImplementation((command: string, args: string[], callback: ExecFileCallback) => {
+      callback(null, '', output);
+      return {} as ChildProcess;
+    });
+
+    const devices = await AudioSource.listDevices('dshow');
+
+    expect(execFileMock).toHaveBeenCalled();
+    expect(devices).toEqual(['Microphone (USB)', 'Line In (High Definition)']);
+  });
+});

--- a/tests/run_guard_multi_camera.test.ts
+++ b/tests/run_guard_multi_camera.test.ts
@@ -1,0 +1,132 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+class MockVideoSource extends EventEmitter {
+  static instances: MockVideoSource[] = [];
+  constructor(public readonly options: { file: string; framesPerSecond: number }) {
+    super();
+    MockVideoSource.instances.push(this);
+  }
+  start() {}
+  stop() {
+    this.emit('stopped');
+  }
+}
+
+class MockPersonDetector {
+  static instances: MockPersonDetector[] = [];
+  static calls: string[] = [];
+  constructor(public readonly options: Record<string, unknown>) {
+    MockPersonDetector.instances.push(this);
+  }
+  static async create(options: Record<string, unknown>) {
+    return new MockPersonDetector(options);
+  }
+  async handleFrame() {
+    MockPersonDetector.calls.push(this.options.source as string);
+  }
+}
+
+class MockMotionDetector {
+  constructor(public readonly options: Record<string, unknown>) {}
+  handleFrame() {}
+}
+
+vi.mock('../src/video/source.js', () => ({
+  VideoSource: MockVideoSource
+}));
+
+vi.mock('../src/video/personDetector.js', () => ({
+  default: MockPersonDetector
+}));
+
+vi.mock('../src/video/motionDetector.js', () => ({
+  default: MockMotionDetector
+}));
+
+vi.mock('../src/video/sampleVideo.js', () => ({
+  ensureSampleVideo: (input: string) => input
+}));
+
+describe('run-guard multi camera orchestration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    MockVideoSource.instances = [];
+    MockPersonDetector.instances = [];
+    MockPersonDetector.calls = [];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('MultiCameraConfig triggers detectors per source', async () => {
+    const { startGuard } = await import('../src/run-guard.ts');
+
+    const bus = new EventEmitter();
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    };
+
+    const runtime = await startGuard({
+      bus,
+      logger,
+      config: {
+        video: {
+          framesPerSecond: 2,
+          cameras: [
+            {
+              id: 'cam-1',
+              channel: 'video:cam-1',
+              input: 'cam-1.mp4',
+              person: {
+                score: 0.6,
+                checkEveryNFrames: 1,
+                maxDetections: 1
+              }
+            },
+            {
+              id: 'cam-2',
+              channel: 'video:cam-2',
+              input: 'cam-2.mp4',
+              person: {
+                score: 0.7,
+                checkEveryNFrames: 1,
+                maxDetections: 1
+              }
+            }
+          ]
+        },
+        person: {
+          modelPath: 'model.onnx',
+          score: 0.5,
+          checkEveryNFrames: 3,
+          maxDetections: 2,
+          snapshotDir: 'snapshots',
+          minIntervalMs: 1000
+        }
+      }
+    });
+
+    expect(MockVideoSource.instances).toHaveLength(2);
+    expect(MockPersonDetector.instances.map(instance => instance.options.source)).toEqual([
+      'video:cam-1',
+      'video:cam-2'
+    ]);
+
+    bus.emit('event', { detector: 'motion', source: 'video:cam-1' });
+    bus.emit('event', { detector: 'motion', source: 'video:cam-2' });
+
+    MockVideoSource.instances[0].emit('frame', Buffer.alloc(0));
+    MockVideoSource.instances[1].emit('frame', Buffer.alloc(0));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(MockPersonDetector.calls).toEqual(['video:cam-1', 'video:cam-2']);
+
+    runtime.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- add YOLO score fusion and NMS to the person detector and extend tests to cover rescaled bounding boxes
- introduce multi-camera guard orchestration with per-source configuration overrides and reconnection logging
- harden the audio source with ffmpeg fallbacks, retry handling, device discovery helpers, and dedicated unit tests

## Testing
- pnpm test -- run
- pnpm test -- run -t PersonNmsParsing
- pnpm test -- run -t MultiCameraConfig
- pnpm test -- run -t AudioSourceFallback
- pnpm tsx src/run-audio-detector.ts
- pnpm tsx src/run-guard.ts


------
https://chatgpt.com/codex/tasks/task_b_68d3d84562988328ad728077640a7749