### PR TITLE
Add CLI controls and expand metrics instrumentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,23 @@ FROM node:20-bookworm-slim AS base
 ENV NODE_ENV=production
 WORKDIR /app
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg \
+  && rm -rf /var/lib/apt/lists/*
 RUN corepack enable
+
+FROM base AS deps
 
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --prod
+# Fail the build early when ffmpeg or onnxruntime native bindings are missing.
+RUN command -v ffmpeg
+RUN node -e "require('onnxruntime-node');"
 
+FROM base AS runner
+
+COPY package.json pnpm-lock.yaml ./
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \

--- a/config/default.json
+++ b/config/default.json
@@ -13,11 +13,33 @@
       "info": 0,
       "warning": 5,
       "critical": 10
+    },
+    "retention": {
+      "retentionDays": 30,
+      "intervalMinutes": 60,
+      "vacuum": "auto",
+      "archiveDir": "archive",
+      "enabled": true
+    },
+    "suppression": {
+      "rules": [
+        {
+          "id": "motion-cooldown",
+          "detector": "motion",
+          "source": "video:test-camera",
+          "suppressForMs": 2000,
+          "reason": "Suppress repeated motion events"
+        }
+      ]
     }
   },
   "video": {
     "testFile": "assets/test-video.mp4",
     "framesPerSecond": 2,
+    "ffmpeg": {
+      "inputArgs": ["-re"],
+      "rtspTransport": "tcp"
+    },
     "cameras": [
       {
         "id": "test-camera",
@@ -25,6 +47,13 @@
         "input": "assets/test-video.mp4",
         "person": {
           "score": 0.5
+        },
+        "motion": {
+          "diffThreshold": 20,
+          "areaThreshold": 0.02
+        },
+        "ffmpeg": {
+          "inputArgs": ["-use_wallclock_as_timestamps", "1"]
         }
       }
     ]

--- a/deploy/guardian.service
+++ b/deploy/guardian.service
@@ -5,9 +5,13 @@ After=network.target
 [Service]
 Type=simple
 Environment=NODE_ENV=production
+Environment=GUARDIAN_CONFIG=/etc/guardian/config.json
+Environment=GUARDIAN_DATA_DIR=/var/lib/guardian
+Environment=PATH=/usr/local/bin:/usr/bin
 WorkingDirectory=/opt/guardian
 ExecStart=/usr/bin/env pnpm start
-ExecReload=/usr/bin/env pnpm health
+ExecReload=/usr/bin/env pnpm exec tsx src/cli.ts --health
+ExecStop=/usr/bin/env pnpm exec tsx src/cli.ts stop
 KillSignal=SIGINT
 Restart=on-failure
 RestartSec=5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       pngjs:
         specifier: ^7.0.0
         version: 7.0.0
+      tsx:
+        specifier: ^4.15.7
+        version: 4.20.5
     devDependencies:
       '@types/config':
         specifier: ^3.3.4
@@ -42,9 +45,6 @@ importers:
       '@types/node':
         specifier: ^20.14.11
         version: 20.19.17
-      tsx:
-        specifier: ^4.15.7
-        version: 4.20.5
       typescript:
         specifier: ^5.5.4
         version: 5.9.2

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8" />
     <title>Guardian Dashboard</title>
     <style>
+      :root {
+        color-scheme: light dark;
+      }
+
       body {
         font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
         margin: 0;
@@ -12,28 +16,14 @@
         color: #1f2933;
       }
 
+      header {
+        max-width: 960px;
+        margin: 0 auto 1.5rem auto;
+      }
+
       h1 {
         margin-top: 0;
-      }
-
-      #events {
-        display: grid;
-        gap: 0.75rem;
-        margin-top: 1rem;
-      }
-
-      .event {
-        background: #fff;
-        border-radius: 0.5rem;
-        box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1);
-        padding: 0.75rem 1rem;
-      }
-
-      .event header {
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        margin-bottom: 0.5rem;
+        margin-bottom: 0.25rem;
       }
 
       .meta {
@@ -41,9 +31,115 @@
         color: #52606d;
       }
 
+      .intro {
+        margin-top: 1rem;
+        padding: 1rem 1.25rem;
+        border-radius: 0.6rem;
+        background: #e4ebf2;
+        color: #243b53;
+        line-height: 1.5;
+      }
+
+      .intro strong {
+        display: block;
+        margin-bottom: 0.35rem;
+      }
+
+      .intro ul {
+        margin: 0.35rem 0 0 1.25rem;
+        padding: 0;
+      }
+
+      .intro li + li {
+        margin-top: 0.25rem;
+      }
+
+      .filters {
+        margin-top: 1rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: flex-end;
+      }
+
+      .filters label {
+        display: flex;
+        flex-direction: column;
+        font-size: 0.85rem;
+        color: #364152;
+        gap: 0.35rem;
+      }
+
+      .filters input,
+      .filters select {
+        border: 1px solid #cbd2d9;
+        border-radius: 0.4rem;
+        padding: 0.45rem 0.6rem;
+        font-size: 0.95rem;
+        min-width: 10rem;
+      }
+
+      .filters button {
+        background: #127fbf;
+        color: #fff;
+        border: none;
+        border-radius: 0.4rem;
+        padding: 0.5rem 1rem;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      .filters button.secondary {
+        background: #e4ebf2;
+        color: #243b53;
+      }
+
+      main.dashboard {
+        max-width: 1200px;
+        margin: 0 auto;
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+        align-items: start;
+      }
+
+      #events {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .event {
+        background: #fff;
+        border-radius: 0.5rem;
+        box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+        padding: 0.75rem 1rem;
+        border: 1px solid transparent;
+        cursor: pointer;
+        transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+      }
+
+      .event:hover {
+        border-color: #8898aa;
+        box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
+      }
+
+      .event.active {
+        border-color: #127fbf;
+        box-shadow: 0 0 0 2px rgba(18, 127, 191, 0.15);
+      }
+
+      .event header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        margin-bottom: 0.5rem;
+        gap: 1rem;
+      }
+
       .severity {
-        font-weight: bold;
+        font-weight: 600;
         text-transform: uppercase;
+        font-size: 0.85rem;
       }
 
       .severity.info {
@@ -57,96 +153,92 @@
       .severity.critical {
         color: #d64545;
       }
+
+      #preview {
+        background: #fff;
+        border-radius: 0.75rem;
+        padding: 1rem;
+        box-shadow: 0 1px 4px rgba(15, 23, 42, 0.08);
+        border: 1px solid #d9e2ec;
+      }
+
+      #preview figure {
+        margin: 0;
+      }
+
+      #preview img {
+        width: 100%;
+        border-radius: 0.5rem;
+        box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.08);
+      }
+
+      .preview-empty {
+        text-align: center;
+        color: #52606d;
+        font-size: 0.95rem;
+      }
+
+      @media (max-width: 960px) {
+        main.dashboard {
+          grid-template-columns: 1fr;
+        }
+      }
     </style>
   </head>
   <body>
-    <h1>Guardian Events</h1>
-    <p class="meta">Streaming live events. The list updates automatically when new events arrive.</p>
-    <div id="events"></div>
+    <header>
+      <h1>Guardian Events</h1>
+      <p class="meta">
+        Streaming live events. Filter by source, channel, or severity to focus on the signals that
+        matter and click an event to preview the latest snapshot.
+      </p>
+      <div class="intro" role="note" aria-label="Dashboard quickstart">
+        <strong>Nasıl kullanılır?</strong>
+        <ul>
+          <li>
+            Sunucuyu <code>pnpm exec tsx src/server/http.ts</code> komutuyla başlatın ve kameralarınızın
+            `config/default.json` içinde tanımlandığından emin olun.
+          </li>
+          <li>Filtreleri kullanarak belirli bir kaynak veya kanal için REST istekleri oluşturabilirsiniz.</li>
+          <li>
+            Liste öğelerinden birine tıklamak, eşleşen snapshot’ı sağdaki panelde açar; kamera meta verileri ve
+            `meta.score` gibi alanlar başlıkta görünür.
+          </li>
+        </ul>
+      </div>
+      <form id="filters" class="filters" aria-label="Event filters">
+        <label>
+          Source
+          <input type="text" name="source" placeholder="video:camera-1" />
+        </label>
+        <label>
+          Channel
+          <input type="text" name="channel" placeholder="video:default" />
+        </label>
+        <label>
+          Severity
+          <select name="severity">
+            <option value="">All levels</option>
+            <option value="info">Info</option>
+            <option value="warning">Warning</option>
+            <option value="critical">Critical</option>
+          </select>
+        </label>
+        <button type="submit">Apply filters</button>
+        <button type="button" id="reset-filters" class="secondary">Reset</button>
+      </form>
+    </header>
+    <main class="dashboard">
+      <section aria-live="polite" aria-label="Live events" id="events"></section>
+      <aside id="preview" aria-label="Snapshot preview">
+        <div class="preview-empty" id="preview-empty">Select an event to view the latest snapshot.</div>
+        <figure id="preview-figure" hidden>
+          <img id="preview-image" alt="Selected event snapshot" />
+          <figcaption class="meta" id="preview-caption"></figcaption>
+        </figure>
+      </aside>
+    </main>
 
-    <script>
-      const list = document.getElementById('events');
-
-      function renderEvent(event) {
-        const container = document.createElement('article');
-        container.className = 'event';
-
-        const header = document.createElement('header');
-        const title = document.createElement('strong');
-        title.textContent = `${event.detector} · ${event.source}`;
-        header.appendChild(title);
-
-        const severity = document.createElement('span');
-        severity.className = `severity ${event.severity}`;
-        severity.textContent = event.severity;
-        header.appendChild(severity);
-
-        const message = document.createElement('p');
-        message.textContent = event.message;
-
-        const timestamp = document.createElement('p');
-        timestamp.className = 'meta';
-        timestamp.textContent = new Date(event.ts).toLocaleString();
-
-        container.appendChild(header);
-        container.appendChild(message);
-        container.appendChild(timestamp);
-
-        if (event.meta && event.meta.snapshot) {
-          const link = document.createElement('a');
-          link.href = `/api/events/${event.id}/snapshot`;
-          link.textContent = 'View snapshot';
-          link.target = '_blank';
-          container.appendChild(link);
-        }
-
-        return container;
-      }
-
-      function prependEvent(event) {
-        const element = renderEvent(event);
-        list.prepend(element);
-        while (list.childElementCount > 25) {
-          list.lastElementChild.remove();
-        }
-      }
-
-      async function loadInitial() {
-        try {
-          const response = await fetch('/api/events?limit=25');
-          if (!response.ok) {
-            return;
-          }
-          const payload = await response.json();
-          if (Array.isArray(payload.items)) {
-            payload.items.forEach(event => {
-              prependEvent(event);
-            });
-          }
-        } catch (error) {
-          console.error('Failed to load events', error);
-        }
-      }
-
-      function subscribe() {
-        const source = new EventSource('/api/events/stream');
-        source.onmessage = event => {
-          try {
-            const payload = JSON.parse(event.data);
-            prependEvent(payload);
-          } catch (error) {
-            console.error('Failed to parse event payload', error);
-          }
-        };
-
-        source.onerror = () => {
-          source.close();
-          setTimeout(subscribe, 3000);
-        };
-      }
-
-      loadInitial();
-      subscribe();
-    </script>
+    <script type="module" src="/dashboard.js"></script>
   </body>
 </html>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ type CliIo = {
 };
 
 type GuardRuntime = {
-  stop: () => void;
+  stop: () => void | Promise<void>;
 };
 
 type HealthPayload = {
@@ -38,18 +38,29 @@ type HealthPayload = {
 
 const DEFAULT_IO: CliIo = { stdout: process.stdout, stderr: process.stderr };
 
+const HEALTH_EXIT_CODES: Record<HealthStatus, number> = {
+  ok: 0,
+  degraded: 1,
+  starting: 2,
+  stopping: 3
+};
+
 const state: {
   status: ServiceStatus;
   startedAt: number | null;
   runtime: GuardRuntime | null;
   stopResolver: (() => void) | null;
   shuttingDown: boolean;
+  shutdownPromise: Promise<void> | null;
+  lastShutdownError: Error | null;
 } = {
   status: 'idle',
   startedAt: null,
   runtime: null,
   stopResolver: null,
-  shuttingDown: false
+  shuttingDown: false,
+  shutdownPromise: null,
+  lastShutdownError: null
 };
 
 export function getServiceState() {
@@ -108,7 +119,7 @@ export async function runCli(argv = process.argv.slice(2), io: CliIo = DEFAULT_I
   if (argv.includes('--health')) {
     const payload = buildHealthPayload();
     io.stdout.write(`${JSON.stringify(payload)}\n`);
-    return payload.status === 'ok' ? 0 : 1;
+    return resolveHealthExitCode(payload.status);
   }
 
   const command = argv[0] ?? 'start';
@@ -117,13 +128,25 @@ export async function runCli(argv = process.argv.slice(2), io: CliIo = DEFAULT_I
     case 'start': {
       return startDaemon(io);
     }
+    case 'stop': {
+      return stopDaemon(io);
+    }
+    case 'status': {
+      return printStatus(io);
+    }
     case 'help':
     case '--help':
     case '-h': {
       io.stdout.write(
-        ['Guardian CLI', '', 'Usage:', '  guardian start       Start the detector daemon', '  guardian --health    Print health JSON'].join(
-          '\n'
-        ) + '\n'
+        [
+          'Guardian CLI',
+          '',
+          'Usage:',
+          '  guardian start        Start the detector daemon',
+          '  guardian stop         Stop the running daemon',
+          '  guardian status       Print service status summary',
+          '  guardian --health     Print health JSON'
+        ].join('\n') + '\n'
       );
       return 0;
     }
@@ -148,8 +171,9 @@ async function startDaemon(io: CliIo): Promise<number> {
   state.status = 'starting';
   state.shuttingDown = false;
 
+  let runtime: GuardRuntime;
   try {
-    state.runtime = await metrics.time('guard.startup.ms', () => startGuard());
+    runtime = await metrics.time('guard.startup.ms', () => startGuard());
   } catch (error) {
     state.status = 'stopped';
     state.runtime = null;
@@ -158,6 +182,20 @@ async function startDaemon(io: CliIo): Promise<number> {
     return 1;
   }
 
+  if (state.status !== 'starting') {
+    try {
+      await Promise.resolve(runtime.stop());
+    } catch (error) {
+      logger.warn({ err: error }, 'Guardian runtime stop failed after aborted start');
+    }
+    const abortedMessage = state.lastShutdownError
+      ? 'Guardian daemon start aborted due to shutdown error\n'
+      : 'Guardian daemon start aborted by shutdown request\n';
+    io.stderr.write(abortedMessage);
+    return state.lastShutdownError ? 1 : 0;
+  }
+
+  state.runtime = runtime;
   state.status = 'running';
   state.startedAt = Date.now();
   logger.info({ startedAt: state.startedAt }, 'Guardian daemon started');
@@ -171,34 +209,97 @@ async function startDaemon(io: CliIo): Promise<number> {
   return 0;
 }
 
-function registerSignalHandlers() {
-  const handleSignal = async (signal: NodeJS.Signals) => {
-    if (state.shuttingDown) {
-      return;
-    }
-    state.shuttingDown = true;
-    state.status = 'stopping';
-    logger.info({ signal }, 'Shutdown signal received');
+async function stopDaemon(io: CliIo): Promise<number> {
+  if ((state.status === 'idle' || state.status === 'stopped') && !state.runtime) {
+    io.stdout.write('Guardian daemon is not running\n');
+    return 0;
+  }
 
-    try {
-      await metrics.time('guard.shutdown.ms', async () => {
-        state.runtime?.stop();
-      });
-    } catch (error) {
-      logger.error({ err: error }, 'Error during shutdown');
-    } finally {
-      state.runtime = null;
-      state.status = 'stopped';
-      state.startedAt = null;
-      state.stopResolver?.();
-      state.stopResolver = null;
-    }
+  const error = await performShutdown('cli-stop');
+  if (error) {
+    io.stderr.write('Guardian daemon encountered an error while stopping. Check logs for details.\n');
+    return 1;
+  }
+
+  io.stdout.write('Guardian daemon stopped\n');
+  return 0;
+}
+
+async function printStatus(io: CliIo): Promise<number> {
+  const payload = buildHealthPayload();
+  const summary = [`Guardian status: ${payload.state}`, `Health: ${payload.status}`];
+
+  const lastError = payload.metrics.logs.lastErrorMessage;
+  if (lastError) {
+    summary.push(`Last error: ${lastError}`);
+  }
+
+  if (payload.metrics.pipelines.ffmpeg.restarts > 0 || payload.metrics.pipelines.audio.restarts > 0) {
+    summary.push(
+      `Restarts - video: ${payload.metrics.pipelines.ffmpeg.restarts}, audio: ${payload.metrics.pipelines.audio.restarts}`
+    );
+  }
+
+  io.stdout.write(summary.join('\n') + '\n');
+  return resolveHealthExitCode(payload.status);
+}
+
+function registerSignalHandlers() {
+  const handleSignal = (signal: NodeJS.Signals) => {
+    void performShutdown('signal', signal);
   };
 
   const signals: NodeJS.Signals[] = ['SIGTERM', 'SIGINT'];
   for (const signal of signals) {
     process.once(signal, handleSignal);
   }
+}
+
+function resolveHealthExitCode(status: HealthStatus) {
+  return HEALTH_EXIT_CODES[status] ?? 1;
+}
+
+async function performShutdown(reason: string, signal?: NodeJS.Signals): Promise<Error | null> {
+  if (state.status === 'idle' || state.status === 'stopped') {
+    return null;
+  }
+
+  if (state.shuttingDown && state.shutdownPromise) {
+    await state.shutdownPromise;
+    return state.lastShutdownError;
+  }
+
+  state.shuttingDown = true;
+  state.status = 'stopping';
+  state.lastShutdownError = null;
+  logger.info({ reason, signal }, 'Guardian daemon shutting down');
+
+  const shutdownTask = (async () => {
+    const runtime = state.runtime;
+    try {
+      await metrics.time('guard.shutdown.ms', async () => {
+        if (runtime) {
+          await Promise.resolve(runtime.stop());
+        }
+      });
+    } catch (error) {
+      const err = error as Error;
+      state.lastShutdownError = err;
+      logger.error({ err }, 'Error during shutdown');
+    } finally {
+      state.runtime = null;
+      state.status = 'stopped';
+      state.startedAt = null;
+      state.stopResolver?.();
+      state.stopResolver = null;
+      state.shuttingDown = false;
+      state.shutdownPromise = null;
+    }
+  })();
+
+  state.shutdownPromise = shutdownTask;
+  await shutdownTask;
+  return state.lastShutdownError;
 }
 
 const resolvedPath = path.resolve(process.argv[1] ?? '');

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -5,6 +5,15 @@ import metrics from './metrics/index.js';
 const level = config.has('logging.level') ? config.get<string>('logging.level') : 'info';
 const name = config.has('app.name') ? config.get<string>('app.name') : 'Guardian';
 
+function extractMessage(args: unknown[]): string | undefined {
+  for (const value of args) {
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 const logger = pino({
   name,
   level,
@@ -12,7 +21,7 @@ const logger = pino({
     logMethod(inputArgs, method, logLevel) {
       const resolvedLevel =
         typeof logLevel === 'number' ? pino.levels.labels[logLevel] ?? String(logLevel) : logLevel;
-      metrics.incrementLogLevel(resolvedLevel);
+      metrics.incrementLogLevel(resolvedLevel, { message: extractMessage(inputArgs) });
       return method.apply(this, inputArgs);
     }
   }

--- a/src/run-video-detectors.ts
+++ b/src/run-video-detectors.ts
@@ -1,66 +1,139 @@
 import config from 'config';
+import ffmpeg from 'fluent-ffmpeg';
+import type { Readable } from 'node:stream';
 import logger from './logger.js';
 import eventBus from './eventBus.js';
 import { ensureSampleVideo } from './video/sampleVideo.js';
 import { VideoSource } from './video/source.js';
 import LightDetector from './video/lightDetector.js';
 import MotionDetector from './video/motionDetector.js';
+import PersonDetector from './video/personDetector.js';
+import type { PersonConfig } from './config/index.js';
 
 const videoConfig = config.get<{ testFile: string; framesPerSecond: number }>('video');
+const personConfig = config.get<PersonConfig>('person');
 const videoFile = ensureSampleVideo(videoConfig.testFile);
 
 const source = new VideoSource({
   file: videoFile,
-  framesPerSecond: videoConfig.framesPerSecond
+  framesPerSecond: videoConfig.framesPerSecond,
+  commandFactory: ({ file, framesPerSecond }) =>
+    ffmpeg(file)
+      .inputOptions('-stream_loop', '-1')
+      .outputOptions('-vf', `fps=${framesPerSecond}`)
+      .outputOptions('-f', 'image2pipe')
+      .outputOptions('-vcodec', 'png')
 });
 
-const motionDetector = new MotionDetector({
-  source: 'video:test-camera',
-  diffThreshold: 25,
-  areaThreshold: 0.015,
-  minIntervalMs: 1500
-});
+const simulateWatchdog = process.env.GUARDIAN_SIMULATE_VIDEO_WATCHDOG ?? '1';
 
-const lightDetector = new LightDetector({
-  source: 'video:test-camera',
-  deltaThreshold: 40,
-  normalHours: [
-    { start: 7, end: 22 }
-  ],
-  smoothingFactor: 0.1,
-  minIntervalMs: 30000
-});
+const parseMs = (value: string | undefined, fallback: number) => {
+  if (!value) {
+    return fallback;
+  }
 
-logger.info({ file: videoFile }, 'Starting video detectors');
-
-eventBus.on('event', payload => {
-  logger.info({ detector: payload.detector, meta: payload.meta }, 'Detector event');
-});
-
-source.on('frame', frame => {
-  motionDetector.handleFrame(frame);
-  lightDetector.handleFrame(frame);
-});
-
-source.on('error', error => {
-  logger.error({ err: error }, 'Video source error');
-});
-
-source.on('end', () => {
-  logger.warn('Video source ended');
-});
-
-source.on('recover', info => {
-  logger.warn({ reason: info.reason, attempt: info.attempt }, 'Video source recovering');
-});
-
-source.start();
-
-const shutdown = (signal: NodeJS.Signals) => {
-  logger.info({ signal }, 'Stopping video detectors');
-  source.stop();
-  process.exit(0);
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
 };
 
-process.once('SIGINT', shutdown);
-process.once('SIGTERM', shutdown);
+const stallDelayMs = parseMs(process.env.GUARDIAN_SIMULATE_VIDEO_WATCHDOG_DELAY_MS, 2000);
+const stallDurationMs = parseMs(process.env.GUARDIAN_SIMULATE_VIDEO_WATCHDOG_DURATION_MS, 7000);
+
+async function main() {
+  const personDetector = await PersonDetector.create({
+    source: 'video:test-camera',
+    modelPath: personConfig.modelPath,
+    scoreThreshold: personConfig.score,
+    snapshotDir: personConfig.snapshotDir,
+    minIntervalMs: personConfig.minIntervalMs
+  });
+
+  if (simulateWatchdog !== '0') {
+    source.once('stream', (stream: Readable) => {
+      setTimeout(() => {
+        if (stream.destroyed) {
+          return;
+        }
+
+        logger.warn(
+          { stallDurationMs },
+          'Pausing video stream to simulate watchdog timeout'
+        );
+        stream.pause();
+
+        if (stallDurationMs > 0) {
+          setTimeout(() => {
+            if (stream.destroyed) {
+              return;
+            }
+
+            logger.info('Resuming video stream after stall simulation');
+            stream.resume();
+          }, stallDurationMs);
+        }
+      }, Math.max(0, stallDelayMs));
+    });
+  }
+
+  const motionDetector = new MotionDetector({
+    source: 'video:test-camera',
+    diffThreshold: 25,
+    areaThreshold: 0.015,
+    minIntervalMs: 1500
+  });
+
+  const lightDetector = new LightDetector({
+    source: 'video:test-camera',
+    deltaThreshold: 40,
+    normalHours: [
+      { start: 7, end: 22 }
+    ],
+    smoothingFactor: 0.1,
+    minIntervalMs: 30000
+  });
+
+  logger.info({ file: videoFile }, 'Starting video detectors');
+
+  eventBus.on('event', payload => {
+    logger.info({ detector: payload.detector, meta: payload.meta }, 'Detector event');
+  });
+
+  source.on('frame', frame => {
+    motionDetector.handleFrame(frame);
+    lightDetector.handleFrame(frame);
+    personDetector.handleFrame(frame).catch(error => {
+      logger.error({ err: error }, 'Person detector failed');
+    });
+  });
+
+  source.on('error', error => {
+    logger.error({ err: error }, 'Video source error');
+  });
+
+  source.on('end', () => {
+    logger.warn('Video source ended');
+  });
+
+  source.on('recover', info => {
+    logger.warn(
+      { reason: info.reason, attempt: info.attempt },
+      `Video source reconnecting (reason=${info.reason})`
+    );
+  });
+
+  source.start();
+
+  const shutdown = (signal: NodeJS.Signals) => {
+    logger.info({ signal }, 'Stopping video detectors');
+    source.stop();
+    process.exit(0);
+  };
+
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+}
+
+main().catch(error => {
+  logger.error({ err: error }, 'Failed to run video detectors demo');
+  process.exit(1);
+});

--- a/src/tasks/retention.ts
+++ b/src/tasks/retention.ts
@@ -1,0 +1,175 @@
+import path from 'node:path';
+import loggerModule from '../logger.js';
+import {
+  applyRetentionPolicy,
+  RetentionOutcome,
+  RetentionPolicyOptions,
+  vacuumDatabase,
+  VacuumMode
+} from '../db.js';
+
+type RetentionLogger = Pick<typeof loggerModule, 'info' | 'warn' | 'error'>;
+
+export interface RetentionTaskOptions {
+  enabled?: boolean;
+  retentionDays: number;
+  intervalMs: number;
+  archiveDir: string;
+  snapshotDirs: string[];
+  vacuumMode?: VacuumMode;
+  logger?: RetentionLogger;
+}
+
+type NormalizedOptions = {
+  enabled: boolean;
+  retentionDays: number;
+  intervalMs: number;
+  archiveDir: string;
+  snapshotDirs: string[];
+  vacuumMode: VacuumMode;
+};
+
+export class RetentionTask {
+  private options: NormalizedOptions;
+  private readonly logger: RetentionLogger;
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private stopped = false;
+
+  constructor(options: RetentionTaskOptions) {
+    this.options = normalizeOptions(options);
+    this.logger = options.logger ?? loggerModule;
+  }
+
+  start() {
+    if (this.timer) {
+      return;
+    }
+
+    this.scheduleNext(0);
+  }
+
+  stop() {
+    this.stopped = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  configure(options: RetentionTaskOptions) {
+    this.options = normalizeOptions(options);
+
+    if (this.stopped) {
+      return;
+    }
+
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+
+    this.scheduleNext(0);
+  }
+
+  private scheduleNext(delayMs: number) {
+    if (this.stopped) {
+      return;
+    }
+
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.runOnce();
+    }, delayMs);
+  }
+
+  private async runOnce() {
+    if (this.running) {
+      return;
+    }
+
+    this.running = true;
+
+    try {
+      if (!this.options.enabled) {
+        this.logger.info({ enabled: false }, 'Retention task skipped');
+        return;
+      }
+
+      const snapshotDirs = dedupeDirectories(this.options.snapshotDirs);
+      const archiveDir = this.options.archiveDir;
+
+      const outcome = runPolicy({
+        retentionDays: this.options.retentionDays,
+        archiveDir,
+        snapshotDirs
+      });
+
+      vacuumDatabase(this.options.vacuumMode);
+
+      this.logger.info(
+        {
+          removedEvents: outcome.removedEvents,
+          archivedSnapshots: outcome.archivedSnapshots,
+          retentionDays: this.options.retentionDays,
+          vacuumMode: this.options.vacuumMode
+        },
+        'Retention task completed'
+      );
+    } catch (error) {
+      this.logger.error({ err: error }, 'Retention task failed');
+    } finally {
+      this.running = false;
+
+      if (!this.stopped) {
+        this.scheduleNext(this.options.intervalMs);
+      }
+    }
+  }
+}
+
+export function startRetentionTask(options: RetentionTaskOptions): RetentionTask {
+  const task = new RetentionTask(options);
+  task.start();
+  return task;
+}
+
+function normalizeOptions(options: RetentionTaskOptions): NormalizedOptions {
+  const intervalMs = Math.max(1000, Math.floor(options.intervalMs));
+  const archiveDir = path.resolve(options.archiveDir);
+  const snapshotDirs = dedupeDirectories(options.snapshotDirs);
+
+  return {
+    enabled: options.enabled !== false,
+    retentionDays: Math.max(0, Math.floor(options.retentionDays)),
+    intervalMs,
+    archiveDir,
+    snapshotDirs,
+    vacuumMode: options.vacuumMode ?? 'auto'
+  };
+}
+
+function dedupeDirectories(directories: string[]): string[] {
+  const set = new Set<string>();
+  for (const entry of directories) {
+    if (!entry) {
+      continue;
+    }
+    set.add(path.resolve(entry));
+  }
+  return [...set];
+}
+
+function runPolicy(options: {
+  retentionDays: number;
+  archiveDir: string;
+  snapshotDirs: string[];
+}): RetentionOutcome {
+  const policy: RetentionPolicyOptions = {
+    retentionDays: options.retentionDays,
+    archiveDir: options.archiveDir,
+    snapshotDirs: options.snapshotDirs
+  };
+
+  return applyRetentionPolicy(policy);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface RateLimitConfig {
 }
 
 export interface EventSuppressionRule {
+  id: string;
   detector?: string | string[];
   source?: string | string[];
   severity?: EventSeverity | EventSeverity[];

--- a/src/video/motionDetector.ts
+++ b/src/video/motionDetector.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from 'node:events';
+import { performance } from 'node:perf_hooks';
 import eventBus from '../eventBus.js';
+import metrics from '../metrics/index.js';
 import { EventPayload } from '../types.js';
 import {
   GrayscaleFrame,
@@ -53,119 +55,148 @@ export class MotionDetector {
   }
 
   handleFrame(frame: Buffer, ts = Date.now()) {
-    const grayscale = readFrameAsGrayscale(frame);
-    const blurred = gaussianBlur(grayscale);
-    const smoothed = medianFilter(blurred);
+    const start = performance.now();
+    try {
+      const grayscale = readFrameAsGrayscale(frame);
+      const blurred = gaussianBlur(grayscale);
+      const smoothed = medianFilter(blurred);
 
-    if (!this.previousFrame) {
+      if (!this.previousFrame) {
+        this.previousFrame = smoothed;
+        this.baselineFrame = smoothed;
+        return;
+      }
+
+      const diffThreshold = this.options.diffThreshold ?? DEFAULT_DIFF_THRESHOLD;
+      const areaThreshold = this.options.areaThreshold ?? DEFAULT_AREA_THRESHOLD;
+      const baseDebounce = this.options.debounceFrames ?? DEFAULT_DEBOUNCE_FRAMES;
+      const baseBackoff = this.options.backoffFrames ?? DEFAULT_BACKOFF_FRAMES;
+      const noiseMultiplier = this.options.noiseMultiplier ?? DEFAULT_NOISE_MULTIPLIER;
+      const baseNoiseSmoothing = this.options.noiseSmoothing ?? DEFAULT_NOISE_SMOOTHING;
+      const baseAreaSmoothing = this.options.areaSmoothing ?? DEFAULT_AREA_SMOOTHING;
+      const areaInflation = this.options.areaInflation ?? DEFAULT_AREA_INFLATION;
+      const areaDeltaThreshold =
+        this.options.areaDeltaThreshold ?? DEFAULT_AREA_DELTA_THRESHOLD;
+
+      const referenceFrame = this.baselineFrame ?? this.previousFrame;
+      const stats = frameDiffStats(referenceFrame, smoothed);
       this.previousFrame = smoothed;
-      this.baselineFrame = smoothed;
-      return;
-    }
 
-    const diffThreshold = this.options.diffThreshold ?? DEFAULT_DIFF_THRESHOLD;
-    const areaThreshold = this.options.areaThreshold ?? DEFAULT_AREA_THRESHOLD;
-    const debounceFrames = this.options.debounceFrames ?? DEFAULT_DEBOUNCE_FRAMES;
-    const backoffFrames = this.options.backoffFrames ?? DEFAULT_BACKOFF_FRAMES;
-    const noiseMultiplier = this.options.noiseMultiplier ?? DEFAULT_NOISE_MULTIPLIER;
-    const noiseSmoothing = this.options.noiseSmoothing ?? DEFAULT_NOISE_SMOOTHING;
-    const areaSmoothing = this.options.areaSmoothing ?? DEFAULT_AREA_SMOOTHING;
-    const areaInflation = this.options.areaInflation ?? DEFAULT_AREA_INFLATION;
-    const areaDeltaThreshold =
-      this.options.areaDeltaThreshold ?? DEFAULT_AREA_DELTA_THRESHOLD;
+      const currentNoiseLevel = this.noiseLevel === 0 ? stats.meanDelta : this.noiseLevel;
+      const noiseRatio = currentNoiseLevel === 0 ? 1 : stats.meanDelta / (currentNoiseLevel || 1);
+      const effectiveNoiseSmoothing = clamp(
+        noiseRatio > 1.1 ? baseNoiseSmoothing * 1.3 : baseNoiseSmoothing * 0.8,
+        0.05,
+        0.5
+      );
+      const adaptiveDiffThreshold = Math.max(diffThreshold, currentNoiseLevel * noiseMultiplier);
 
-    const referenceFrame = this.baselineFrame ?? this.previousFrame;
-    const stats = frameDiffStats(referenceFrame, smoothed);
-    this.previousFrame = smoothed;
-
-    const currentNoiseLevel = this.noiseLevel === 0 ? stats.meanDelta : this.noiseLevel;
-    const adaptiveDiffThreshold = Math.max(diffThreshold, currentNoiseLevel * noiseMultiplier);
-
-    let changedPixels = 0;
-    for (let i = 0; i < stats.totalPixels; i += 1) {
-      if (stats.deltas[i] >= adaptiveDiffThreshold) {
-        changedPixels += 1;
+      let changedPixels = 0;
+      for (let i = 0; i < stats.totalPixels; i += 1) {
+        if (stats.deltas[i] >= adaptiveDiffThreshold) {
+          changedPixels += 1;
+        }
       }
-    }
 
-    const areaPct = changedPixels / stats.totalPixels;
+      const areaPct = changedPixels / stats.totalPixels;
 
-    const baselineForThreshold = this.areaBaseline;
-    const adaptiveAreaThreshold = Math.max(
-      areaThreshold,
-      baselineForThreshold * areaInflation
-    );
+      const baselineForThreshold = this.areaBaseline;
+      const adaptiveAreaThreshold = Math.max(
+        areaThreshold,
+        baselineForThreshold * areaInflation
+      );
+      const effectiveAreaSmoothing = clamp(
+        areaPct >= baselineForThreshold ? baseAreaSmoothing * 1.2 : baseAreaSmoothing * 0.7,
+        0.05,
+        0.5
+      );
+      const effectiveDebounceFrames = noiseRatio > 1.1 ? Math.max(baseDebounce, Math.round(baseDebounce * 1.5)) : baseDebounce;
+      const effectiveBackoffFrames =
+        areaPct >= adaptiveAreaThreshold
+          ? baseBackoff
+          : Math.max(baseBackoff, Math.round(baseBackoff * 1.5));
 
-    const nextBaseline =
-      baselineForThreshold === 0
-        ? areaPct * areaSmoothing
-        : baselineForThreshold * (1 - areaSmoothing) + areaPct * areaSmoothing;
+      const nextBaseline =
+        baselineForThreshold === 0
+          ? areaPct * effectiveAreaSmoothing
+          : baselineForThreshold * (1 - effectiveAreaSmoothing) + areaPct * effectiveAreaSmoothing;
 
-    const areaDelta = baselineForThreshold === 0 ? areaPct : areaPct - baselineForThreshold;
-    const hasSignificantArea =
-      areaPct >= adaptiveAreaThreshold || areaDelta >= areaDeltaThreshold;
+      const areaDelta = baselineForThreshold === 0 ? areaPct : areaPct - baselineForThreshold;
+      const hasSignificantArea =
+        areaPct >= adaptiveAreaThreshold || areaDelta >= areaDeltaThreshold;
 
-    if (!hasSignificantArea) {
-      if (this.noiseLevel === 0) {
-        this.noiseLevel = stats.meanDelta;
-      } else {
-        this.noiseLevel =
-          this.noiseLevel * (1 - noiseSmoothing) + stats.meanDelta * noiseSmoothing;
+      if (!hasSignificantArea) {
+        if (this.noiseLevel === 0) {
+          this.noiseLevel = stats.meanDelta;
+        } else {
+          this.noiseLevel =
+            this.noiseLevel * (1 - effectiveNoiseSmoothing) + stats.meanDelta * effectiveNoiseSmoothing;
+        }
+
+        this.areaBaseline = nextBaseline;
+        this.baselineFrame = smoothed;
+        this.activationFrames = 0;
+        if (this.backoffFrames > 0) {
+          this.backoffFrames -= 1;
+        }
+        return;
       }
+
+      this.noiseLevel =
+        this.noiseLevel * (1 - effectiveNoiseSmoothing) + stats.meanDelta * effectiveNoiseSmoothing;
 
       this.areaBaseline = nextBaseline;
-      this.baselineFrame = smoothed;
-      this.activationFrames = 0;
+
       if (this.backoffFrames > 0) {
         this.backoffFrames -= 1;
+        return;
       }
-      return;
-    }
 
-    this.noiseLevel =
-      this.noiseLevel * (1 - noiseSmoothing) + stats.meanDelta * noiseSmoothing;
-
-    this.areaBaseline = nextBaseline;
-
-    if (this.backoffFrames > 0) {
-      this.backoffFrames -= 1;
-      return;
-    }
-
-    this.activationFrames += 1;
-    if (this.activationFrames < debounceFrames) {
-      return;
-    }
-
-    this.activationFrames = 0;
-
-    if (ts - this.lastEventTs < (this.options.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS)) {
-      return;
-    }
-
-    this.lastEventTs = ts;
-    this.backoffFrames = backoffFrames;
-
-    const payload: EventPayload = {
-      ts,
-      detector: 'motion',
-      source: this.options.source,
-      severity: 'warning',
-      message: 'Motion detected',
-      meta: {
-        areaPct,
-        areaThreshold,
-        diffThreshold,
-        adaptiveDiffThreshold,
-        adaptiveAreaThreshold,
-        noiseLevel: this.noiseLevel,
-        areaDelta,
-        areaDeltaThreshold
+      this.activationFrames += 1;
+      if (this.activationFrames < effectiveDebounceFrames) {
+        return;
       }
-    };
 
-    this.bus.emit('event', payload);
+      this.activationFrames = 0;
+
+      if (ts - this.lastEventTs < (this.options.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS)) {
+        return;
+      }
+
+      this.lastEventTs = ts;
+      this.backoffFrames = effectiveBackoffFrames;
+
+      const payload: EventPayload = {
+        ts,
+        detector: 'motion',
+        source: this.options.source,
+        severity: 'warning',
+        message: 'Motion detected',
+        meta: {
+          areaPct,
+          areaThreshold,
+          diffThreshold,
+          adaptiveDiffThreshold,
+          adaptiveAreaThreshold,
+          noiseLevel: this.noiseLevel,
+          areaDelta,
+          areaDeltaThreshold,
+          effectiveDebounceFrames,
+          effectiveBackoffFrames,
+          noiseSmoothing: effectiveNoiseSmoothing,
+          areaSmoothing: effectiveAreaSmoothing
+        }
+      };
+
+      this.bus.emit('event', payload);
+    } finally {
+      metrics.observeDetectorLatency('motion', performance.now() - start);
+    }
   }
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
 }
 
 export default MotionDetector;

--- a/tests/audio_anomaly.test.ts
+++ b/tests/audio_anomaly.test.ts
@@ -36,6 +36,8 @@ describe('AudioWindowing', () => {
   const sampleRate = 16000;
   const frameSize = 1024;
   const hopSize = 512;
+  const frameDurationMs = (frameSize / sampleRate) * 1000;
+  const hopDurationMs = (hopSize / sampleRate) * 1000;
   let bus: EventEmitter;
   let events: CapturedEvent[];
 
@@ -52,8 +54,8 @@ describe('AudioWindowing', () => {
       {
         source: 'audio:test',
         sampleRate,
-        frameSize,
-        hopSize,
+        frameDurationMs,
+        hopDurationMs,
         rmsThreshold: 0.5,
         centroidJumpThreshold: 5000,
         minIntervalMs: 0,
@@ -78,8 +80,8 @@ describe('AudioWindowing', () => {
       {
         source: 'audio:test',
         sampleRate,
-        frameSize,
-        hopSize,
+        frameDurationMs,
+        hopDurationMs,
         rmsThreshold: 0.4,
         centroidJumpThreshold: 5000,
         minIntervalMs: 0,
@@ -97,6 +99,9 @@ describe('AudioWindowing', () => {
     expect(events[0].detector).toBe('audio-anomaly');
     expect(events[0].meta?.triggeredBy).toBe('rms');
     expect(Number(events[0].meta?.durationAboveThresholdMs)).toBeGreaterThanOrEqual(100);
+    const windowMeta = events[0].meta?.window as Record<string, number>;
+    expect(Number(windowMeta?.frameDurationMs)).toBeCloseTo(frameDurationMs, 3);
+    expect(Number(windowMeta?.hopDurationMs)).toBeCloseTo(hopDurationMs, 3);
   });
 
   it('detects sustained spectral centroid shifts', () => {
@@ -104,8 +109,8 @@ describe('AudioWindowing', () => {
       {
         source: 'audio:test',
         sampleRate,
-        frameSize,
-        hopSize,
+        frameDurationMs,
+        hopDurationMs,
         rmsThreshold: 0.6,
         centroidJumpThreshold: 50,
         minIntervalMs: 0,

--- a/tests/cli_health.test.ts
+++ b/tests/cli_health.test.ts
@@ -1,34 +1,109 @@
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { Writable } from 'node:stream';
+import metrics from '../src/metrics/index.js';
 
-const execFileAsync = promisify(execFile);
+const startGuardMock = vi.fn();
+vi.mock('../src/run-guard.js', () => ({
+  startGuard: startGuardMock
+}));
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const projectRoot = path.resolve(__dirname, '..');
+import { runCli } from '../src/cli.js';
 
-describe('GuardianCliHealthcheck', () => {
-  it('returns JSON payload for --health', async () => {
-    const cliPath = path.resolve(projectRoot, 'src/cli.ts');
+type TestIo = {
+  io: { stdout: NodeJS.WritableStream; stderr: NodeJS.WritableStream };
+  stdout: () => string;
+  stderr: () => string;
+};
 
-    const { stdout } = await execFileAsync('pnpm', ['exec', 'tsx', cliPath, '--health'], {
-      cwd: projectRoot,
-      env: {
-        ...process.env,
-        NODE_ENV: 'test'
+function createTestIo(): TestIo {
+  let stdout = '';
+  let stderr = '';
+
+  const makeWritable = (setter: (value: string) => void) =>
+    new Writable({
+      write(chunk, _enc, callback) {
+        setter(typeof chunk === 'string' ? chunk : chunk.toString());
+        callback();
       }
     });
 
-    const payload = JSON.parse(stdout.trim());
+  return {
+    io: {
+      stdout: makeWritable(value => {
+        stdout += value;
+      }),
+      stderr: makeWritable(value => {
+        stderr += value;
+      })
+    },
+    stdout: () => stdout,
+    stderr: () => stderr
+  };
+}
 
+beforeEach(async () => {
+  startGuardMock.mockReset();
+  metrics.reset();
+  const cleanupIo = createTestIo();
+  await runCli(['stop'], cleanupIo.io);
+});
+
+afterEach(async () => {
+  const cleanupIo = createTestIo();
+  await runCli(['stop'], cleanupIo.io);
+});
+
+describe('GuardianCliHealthcheck', () => {
+  it('returns JSON payload for --health and embeds pipeline metrics', async () => {
+    const capture = createTestIo();
+    const code = await runCli(['--health'], capture.io);
+    const payload = JSON.parse(capture.stdout().trim());
+
+    expect(code).toBe(0);
     expect(payload.status).toBe('ok');
-    expect(payload.state).toBeTypeOf('string');
-    expect(payload.metrics).toBeDefined();
-    expect(payload.application.name).toBe('guardian');
-    expect(Array.isArray(payload.checks)).toBe(true);
-    expect(payload.checks[0]).toHaveProperty('name');
+    expect(payload.metrics.pipelines.ffmpeg).toBeDefined();
+    expect(payload.metrics.pipelines.audio).toBeDefined();
+  });
+
+  it('propagates degraded exit code when error logs are present', async () => {
+    metrics.incrementLogLevel('error', { message: 'detector failure' });
+    const capture = createTestIo();
+    const code = await runCli(['--health'], capture.io);
+
+    expect(code).toBe(1);
+    const payload = JSON.parse(capture.stdout().trim());
+    expect(payload.status).toBe('degraded');
+  });
+
+  it('summarizes status output with restart counters', async () => {
+    metrics.recordPipelineRestart('ffmpeg', 'watchdog-timeout');
+    metrics.recordPipelineRestart('audio', 'spawn-error');
+    const capture = createTestIo();
+    const code = await runCli(['status'], capture.io);
+
+    expect(code).toBe(0);
+    expect(capture.stdout()).toContain('Restarts - video: 1, audio: 1');
+  });
+});
+
+describe('GuardianCliShutdown', () => {
+  it('stops the running guard runtime and reports graceful shutdown', async () => {
+    const stopSpy = vi.fn();
+    startGuardMock.mockResolvedValue({ stop: stopSpy });
+
+    const startIo = createTestIo();
+    const startPromise = runCli(['start'], startIo.io);
+
+    await vi.waitFor(() => {
+      expect(startGuardMock).toHaveBeenCalledTimes(1);
+    });
+
+    const stopIo = createTestIo();
+    const stopCode = await runCli(['stop'], stopIo.io);
+
+    expect(stopCode).toBe(0);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(stopIo.stdout()).toContain('Guardian daemon stopped');
+    await expect(startPromise).resolves.toBe(0);
   });
 });

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -3,11 +3,16 @@ import { EventBus } from '../src/eventBus.js';
 import { MetricsRegistry } from '../src/metrics/index.js';
 
 function createBus() {
+  const metrics = {
+    recordEvent: vi.fn(),
+    recordSuppressedEvent: vi.fn()
+  };
   return new EventBus({
     store: vi.fn(),
     log: {
       info: vi.fn()
-    } as any
+    } as any,
+    metrics: metrics as any
   });
 }
 
@@ -54,5 +59,28 @@ describe('MetricsCounters', () => {
     expect(snapshot.latencies['pipeline.latency']).toBeDefined();
     expect(snapshot.latencies['pipeline.latency'].count).toBe(1);
     expect(snapshot.latencies['pipeline.latency'].maxMs).toBeGreaterThan(0);
+  });
+
+  it('MetricsPipelineCounters records detector histograms and pipeline counters', () => {
+    const registry = new MetricsRegistry();
+
+    registry.observeDetectorLatency('motion', 42);
+    registry.observeDetectorLatency('motion', 120);
+    registry.recordPipelineRestart('ffmpeg', 'watchdog-timeout');
+    registry.recordPipelineRestart('ffmpeg', 'watchdog-timeout');
+    registry.recordPipelineRestart('audio', 'spawn-error');
+    registry.recordSuppressedEvent('rule-1', 'cooldown');
+
+    const snapshot = registry.snapshot();
+
+    expect(snapshot.latencies['detector.motion.latency'].count).toBe(2);
+    expect(snapshot.histograms['detector.motion.latency']['25-50']).toBe(1);
+    expect(snapshot.histograms['detector.motion.latency']['100-250']).toBe(1);
+    expect(snapshot.pipelines.ffmpeg.restarts).toBe(2);
+    expect(snapshot.pipelines.ffmpeg.byReason['watchdog-timeout']).toBe(2);
+    expect(snapshot.pipelines.audio.restarts).toBe(1);
+    expect(snapshot.suppression.total).toBe(1);
+    expect(snapshot.suppression.byRule['rule-1']).toBe(1);
+    expect(snapshot.suppression.byReason['cooldown']).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- add CLI stop/status commands with refined health exit codes and shared shutdown handling for the guard runtime
- enrich the metrics registry with pipeline restart counters, detector latency histograms, and suppression tracking while instrumenting video/audio sources and detectors
- update the Docker image and systemd unit to verify ffmpeg/onnxruntime availability and use the CLI for service control
- cover the new behaviour with focused CLI and metrics tests
- document RTSP and multi-camera setup, retention lifecycle management, dashboard usage, and dependency requirements

## Testing
- pnpm vitest run -t GuardianCliShutdown
- pnpm vitest run -t GuardianCliHealthcheck
- pnpm vitest run -t MetricsPipelineCounters
- pnpm vitest run -t MetricsCounters

------
https://chatgpt.com/codex/tasks/task_b_68d408076a088328854b9cead48481d7