### PR TITLE
Add CLI health lifecycle hooks and detector metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ COPY package.json pnpm-lock.yaml ./
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+STOPSIGNAL SIGTERM
+
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD pnpm exec tsx src/cli.ts --health || exit 1
 

--- a/config/default.json
+++ b/config/default.json
@@ -17,9 +17,20 @@
     "retention": {
       "retentionDays": 30,
       "intervalMinutes": 60,
-      "vacuum": "auto",
       "archiveDir": "archive",
-      "enabled": true
+      "enabled": true,
+      "maxArchivesPerCamera": 5,
+      "snapshot": {
+        "mode": "archive",
+        "retentionDays": 21
+      },
+      "vacuum": {
+        "mode": "auto",
+        "analyze": true,
+        "reindex": true,
+        "optimize": true,
+        "target": "main"
+      }
     },
     "suppression": {
       "rules": [
@@ -47,6 +58,13 @@
       "restartMaxDelayMs": 5000,
       "restartJitterFactor": 0.2
     },
+    "channels": {
+      "video:test-camera": {
+        "ffmpeg": {
+          "inputArgs": ["-use_wallclock_as_timestamps", "1"]
+        }
+      }
+    },
     "cameras": [
       {
         "id": "test-camera",
@@ -65,9 +83,6 @@
           "areaSmoothing": 0.2,
           "areaInflation": 1.2,
           "areaDeltaThreshold": 0.015
-        },
-        "ffmpeg": {
-          "inputArgs": ["-use_wallclock_as_timestamps", "1"]
         }
       }
     ]
@@ -78,7 +93,8 @@
     "checkEveryNFrames": 3,
     "maxDetections": 5,
     "snapshotDir": "snapshots",
-    "minIntervalMs": 2000
+    "minIntervalMs": 2000,
+    "classIndices": [0, 15, 16]
   },
   "motion": {
     "diffThreshold": 25,
@@ -103,6 +119,24 @@
     "normalHours": [
       { "start": 7, "end": 22 }
     ]
+  },
+  "pose": {
+    "modelPath": "models/pose.onnx",
+    "forecastHorizonMs": 900,
+    "smoothingWindow": 3,
+    "minMovement": 0.05,
+    "historySize": 12
+  },
+  "face": {
+    "modelPath": "models/face.onnx",
+    "embeddingSize": 128
+  },
+  "objects": {
+    "modelPath": "models/object.onnx",
+    "labels": ["pet", "delivery", "threat"],
+    "threatLabels": ["threat"],
+    "threatThreshold": 0.6,
+    "classIndices": [15, 16]
   },
   "audio": {
     "idleTimeoutMs": 4000,

--- a/deploy/systemd.service
+++ b/deploy/systemd.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Guardian detector service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/guardian
+Environment=NODE_ENV=production
+EnvironmentFile=-/etc/default/guardian
+ExecStart=/usr/bin/env pnpm exec tsx src/cli.ts start
+ExecStop=/usr/bin/env pnpm exec tsx src/cli.ts stop
+ExecReload=/usr/bin/env pnpm exec tsx src/cli.ts status
+Restart=on-failure
+RestartSec=5
+KillSignal=SIGTERM
+TimeoutStopSec=60
+
+[Install]
+WantedBy=multi-user.target

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/config": "^3.3.4",
     "@types/fluent-ffmpeg": "^2.1.24",
     "@types/node": "^20.14.11",
+    "jsdom": "^27.0.0",
     "typescript": "^5.5.4",
     "vitest": "^1.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,14 +45,60 @@ importers:
       '@types/node':
         specifier: ^20.14.11
         version: 20.19.17
+      jsdom:
+        specifier: ^27.0.0
+        version: 27.0.0(postcss@8.5.6)
       typescript:
         specifier: ^5.5.4
         version: 5.9.2
       vitest:
         specifier: ^1.6.0
-        version: 1.6.1(@types/node@20.19.17)
+        version: 1.6.1(@types/node@20.19.17)(jsdom@27.0.0(postcss@8.5.6))
 
 packages:
+
+  '@asamuzakjp/css-color@4.0.5':
+    resolution: {integrity: sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==}
+
+  '@asamuzakjp/dom-selector@6.5.6':
+    resolution: {integrity: sha512-Mj3Hu9ymlsERd7WOsUKNUZnJYL4IZ/I9wVVYgtvOsWYiEFbkQ4G7VRIh2USxTVW4BBDIsLG+gBUgqOqf2Kvqow==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14':
+    resolution: {integrity: sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@derhuerst/http-basic@8.2.4':
     resolution: {integrity: sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==}
@@ -544,6 +590,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
@@ -566,6 +616,9 @@ packages:
 
   better-sqlite3@9.6.0:
     resolution: {integrity: sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -630,6 +683,18 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssstyle@5.3.1:
+    resolution: {integrity: sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==}
+    engines: {node: '>=20'}
+
+  data-urls@6.0.0:
+    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
+    engines: {node: '>=20'}
+
   dct@0.1.0:
     resolution: {integrity: sha512-/uUtEniuMq1aUxvLAoDtAduyl12oM1zhA/le2f83UFN/9+4KDHXFB6znEfoj5SDDLiTpUTr26NpxC7t8IFOYhQ==}
     engines: {node: '>=0.12.0'}
@@ -650,6 +715,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -688,6 +756,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -802,6 +874,14 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   http-response-object@3.0.2:
     resolution: {integrity: sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==}
 
@@ -809,9 +889,17 @@ packages:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
 
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -829,6 +917,9 @@ packages:
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -841,6 +932,15 @@ packages:
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@27.0.0:
+    resolution: {integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -857,12 +957,19 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
+  lru-cache@11.2.2:
+    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -943,6 +1050,9 @@ packages:
   parse-cache-control@1.0.1:
     resolution: {integrity: sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -1014,6 +1124,10 @@ packages:
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
@@ -1039,6 +1153,10 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -1056,12 +1174,22 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
@@ -1140,6 +1268,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -1160,6 +1291,21 @@ packages:
   tinyspy@2.2.1:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.16:
+    resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
+
+  tldts@7.0.16:
+    resolution: {integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==}
+    hasBin: true
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tsx@4.20.5:
     resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
@@ -1255,8 +1401,28 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   wav@1.0.2:
     resolution: {integrity: sha512-viHtz3cDd/Tcr/HbNqzQCofKdF6kWUymH9LGDdskfWFoIy/HJ+RTihgjEcHfnsy1PO4e9B+y4HwgTwMrByquhg==}
+
+  webidl-conversions@8.0.0:
+    resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
+    engines: {node: '>=20'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
 
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -1275,11 +1441,72 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yocto-queue@1.2.1:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
 
 snapshots:
+
+  '@asamuzakjp/css-color@4.0.5':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.2
+
+  '@asamuzakjp/dom-selector@6.5.6':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.2
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@derhuerst/http-basic@8.2.4':
     dependencies:
@@ -1590,6 +1817,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   ansi-styles@5.2.0: {}
 
   assertion-error@1.1.0: {}
@@ -1606,6 +1835,10 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bindings@1.5.0:
     dependencies:
@@ -1681,6 +1914,24 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
+  cssstyle@5.3.1(postcss@8.5.6):
+    dependencies:
+      '@asamuzakjp/css-color': 4.0.5
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.5.6)
+      css-tree: 3.1.0
+    transitivePeerDependencies:
+      - postcss
+
+  data-urls@6.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+
   dct@0.1.0: {}
 
   debug@2.6.9:
@@ -1690,6 +1941,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -1724,6 +1977,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  entities@6.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -1877,6 +2132,17 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-response-object@3.0.2:
     dependencies:
       '@types/node': 10.17.60
@@ -1888,7 +2154,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-signals@5.0.0: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -1902,6 +2179,8 @@ snapshots:
 
   is-module@1.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-stream@3.0.0: {}
 
   isarray@0.0.1: {}
@@ -1909,6 +2188,34 @@ snapshots:
   isexe@2.0.0: {}
 
   js-tokens@9.0.1: {}
+
+  jsdom@27.0.0(postcss@8.5.6):
+    dependencies:
+      '@asamuzakjp/dom-selector': 6.5.6
+      cssstyle: 5.3.1(postcss@8.5.6)
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - postcss
+      - supports-color
+      - utf-8-validate
 
   json-stringify-safe@5.0.1: {}
 
@@ -1923,6 +2230,8 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  lru-cache@11.2.2: {}
+
   magic-string@0.30.19:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1930,6 +2239,8 @@ snapshots:
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
+
+  mdn-data@2.12.2: {}
 
   merge-stream@2.0.0: {}
 
@@ -2002,6 +2313,10 @@ snapshots:
       yocto-queue: 1.2.1
 
   parse-cache-control@1.0.1: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-key@3.1.1: {}
 
@@ -2086,6 +2401,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode@2.3.1: {}
+
   quick-format-unescaped@4.0.4: {}
 
   rc@1.2.8:
@@ -2119,6 +2436,8 @@ snapshots:
       string_decoder: 1.3.0
 
   real-require@0.2.0: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -2165,9 +2484,17 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.2
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   safe-buffer@5.2.1: {}
 
   safe-stable-stringify@2.5.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   semver-compare@1.0.0: {}
 
@@ -2231,6 +2558,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -2255,6 +2584,20 @@ snapshots:
   tinypool@0.8.4: {}
 
   tinyspy@2.2.1: {}
+
+  tldts-core@7.0.16: {}
+
+  tldts@7.0.16:
+    dependencies:
+      tldts-core: 7.0.16
+
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.16
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tsx@4.20.5:
     dependencies:
@@ -2308,7 +2651,7 @@ snapshots:
       '@types/node': 20.19.17
       fsevents: 2.3.3
 
-  vitest@1.6.1(@types/node@20.19.17):
+  vitest@1.6.1(@types/node@20.19.17)(jsdom@27.0.0(postcss@8.5.6)):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -2332,6 +2675,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.17
+      jsdom: 27.0.0(postcss@8.5.6)
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -2342,6 +2686,10 @@ snapshots:
       - supports-color
       - terser
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   wav@1.0.2:
     dependencies:
       buffer-alloc: 1.2.0
@@ -2351,6 +2699,19 @@ snapshots:
       stream-parser: 0.3.1
     transitivePeerDependencies:
       - supports-color
+
+  webidl-conversions@8.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.0
 
   which@1.3.1:
     dependencies:
@@ -2366,5 +2727,11 @@ snapshots:
       stackback: 0.0.2
 
   wrappy@1.0.2: {}
+
+  ws@8.18.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yocto-queue@1.2.1: {}

--- a/public/index.html
+++ b/public/index.html
@@ -70,6 +70,10 @@
         gap: 0.35rem;
       }
 
+      .filters label.wide {
+        flex: 1 1 16rem;
+      }
+
       .filters input,
       .filters select {
         border: 1px solid #cbd2d9;
@@ -94,6 +98,41 @@
         color: #243b53;
       }
 
+      .stream-widget {
+        background: #fff;
+        border-radius: 0.75rem;
+        padding: 1rem 1.25rem;
+        box-shadow: 0 1px 4px rgba(15, 23, 42, 0.08);
+        border: 1px solid #d9e2ec;
+      }
+
+      .stream-widget h2 {
+        margin: 0 0 0.75rem 0;
+        font-size: 1.05rem;
+        color: #243b53;
+      }
+
+      .stream-widget dl {
+        margin: 0;
+        display: grid;
+        gap: 0.5rem 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      }
+
+      .stream-widget dt {
+        font-weight: 600;
+        font-size: 0.8rem;
+        color: #52606d;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      .stream-widget dd {
+        margin: 0;
+        font-size: 0.95rem;
+        color: #1f2933;
+      }
+
       main.dashboard {
         max-width: 1200px;
         margin: 0 auto;
@@ -101,6 +140,12 @@
         gap: 1.5rem;
         grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
         align-items: start;
+      }
+
+      #event-column {
+        display: grid;
+        gap: 1.5rem;
+        align-content: start;
       }
 
       #events {
@@ -219,6 +264,10 @@
           Channel
           <input type="text" name="channel" placeholder="video:default" />
         </label>
+        <label class="wide">
+          Search
+          <input type="text" name="search" placeholder="message or detector" />
+        </label>
         <label>
           Severity
           <select name="severity">
@@ -226,6 +275,14 @@
             <option value="info">Info</option>
             <option value="warning">Warning</option>
             <option value="critical">Critical</option>
+          </select>
+        </label>
+        <label>
+          Snapshot
+          <select name="snapshot">
+            <option value="">Any snapshot</option>
+            <option value="with">With snapshot</option>
+            <option value="without">Without snapshot</option>
           </select>
         </label>
         <label>
@@ -241,7 +298,22 @@
       </form>
     </header>
     <main class="dashboard">
-      <section aria-live="polite" aria-label="Live events" id="events"></section>
+      <div id="event-column">
+        <section class="stream-widget" aria-live="polite" aria-label="Stream activity">
+          <h2>Live stream</h2>
+          <dl>
+            <dt>Status</dt>
+            <dd id="stream-state">Connecting…</dd>
+            <dt>Heartbeats</dt>
+            <dd id="stream-heartbeats">0</dd>
+            <dt>Events</dt>
+            <dd id="stream-events">0</dd>
+            <dt>Last update</dt>
+            <dd id="stream-updated">—</dd>
+          </dl>
+        </section>
+        <section aria-live="polite" aria-label="Live events" id="events"></section>
+      </div>
       <aside id="preview" aria-label="Snapshot preview">
         <div class="preview-empty" id="preview-empty">Select an event to view the latest snapshot.</div>
         <figure id="preview-figure" hidden>

--- a/scripts/vacuum.ts
+++ b/scripts/vacuum.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env tsx
+import process from 'node:process';
+import { vacuumDatabase, VacuumMode, VacuumOptions } from '../src/db.js';
+import logger from '../src/logger.js';
+
+function parseArgs(argv: string[]): VacuumOptions {
+  const options: VacuumOptions = {};
+  const pragmas: string[] = [];
+
+  for (const arg of argv) {
+    if (arg.startsWith('--mode=')) {
+      const mode = arg.split('=')[1] as VacuumMode;
+      if (mode === 'auto' || mode === 'full') {
+        options.mode = mode;
+      }
+      continue;
+    }
+
+    if (arg === '--full') {
+      options.mode = 'full';
+      continue;
+    }
+
+    if (arg === '--analyze') {
+      options.analyze = true;
+      continue;
+    }
+
+    if (arg === '--reindex') {
+      options.reindex = true;
+      continue;
+    }
+
+    if (arg === '--optimize') {
+      options.optimize = true;
+      continue;
+    }
+
+    if (arg.startsWith('--target=')) {
+      options.target = arg.split('=')[1] ?? undefined;
+      continue;
+    }
+
+    if (arg.startsWith('--pragma=')) {
+      const pragma = arg.slice('--pragma='.length);
+      if (pragma) {
+        pragmas.push(pragma);
+      }
+      continue;
+    }
+  }
+
+  if (pragmas.length > 0) {
+    options.pragmas = pragmas;
+  }
+
+  return options;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const options = parseArgs(args);
+
+  logger.info({ options }, 'running manual vacuum');
+  vacuumDatabase(options);
+  logger.info('vacuum completed');
+}
+
+main().catch(error => {
+  logger.error({ err: error }, 'vacuum command failed');
+  process.exitCode = 1;
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,117 @@ import { fileURLToPath } from 'node:url';
 import eventBus from './eventBus.js';
 import logger from './logger.js';
 
+type HealthStatus = 'ok' | 'starting' | 'stopping' | 'degraded';
+
+export type HealthIndicatorContext = {
+  service: {
+    status: string;
+    startedAt: number | null;
+  };
+};
+
+export type HealthIndicatorResult = {
+  status: HealthStatus;
+  details?: Record<string, unknown>;
+};
+
+export type HealthIndicator = (context: HealthIndicatorContext) =>
+  | HealthIndicatorResult
+  | Promise<HealthIndicatorResult>;
+
+export type ShutdownHookContext = {
+  reason: string;
+  signal?: NodeJS.Signals;
+};
+
+export type ShutdownHook = (context: ShutdownHookContext) => void | Promise<void>;
+
+type RegisteredIndicator = {
+  name: string;
+  indicator: HealthIndicator;
+};
+
+type RegisteredHook = {
+  name: string;
+  hook: ShutdownHook;
+};
+
+const healthIndicators: RegisteredIndicator[] = [];
+const shutdownHooks: RegisteredHook[] = [];
+
+export function registerHealthIndicator(name: string, indicator: HealthIndicator) {
+  const existingIndex = healthIndicators.findIndex(entry => entry.name === name);
+  const entry: RegisteredIndicator = { name, indicator };
+  if (existingIndex >= 0) {
+    healthIndicators[existingIndex] = entry;
+  } else {
+    healthIndicators.push(entry);
+  }
+
+  return () => {
+    const index = healthIndicators.findIndex(item => item.name === name);
+    if (index >= 0) {
+      healthIndicators.splice(index, 1);
+    }
+  };
+}
+
+export async function collectHealthChecks(context: HealthIndicatorContext) {
+  const results: Array<{ name: string; status: HealthStatus; details?: Record<string, unknown> }> = [];
+  for (const entry of healthIndicators) {
+    try {
+      const result = await entry.indicator(context);
+      results.push({ name: entry.name, status: result.status, details: result.details });
+    } catch (error) {
+      const err = error as Error;
+      results.push({
+        name: entry.name,
+        status: 'degraded',
+        details: {
+          error: err.message ?? String(err)
+        }
+      });
+    }
+  }
+  return results;
+}
+
+export function registerShutdownHook(name: string, hook: ShutdownHook) {
+  const existingIndex = shutdownHooks.findIndex(entry => entry.name === name);
+  const entry: RegisteredHook = { name, hook };
+  if (existingIndex >= 0) {
+    shutdownHooks[existingIndex] = entry;
+  } else {
+    shutdownHooks.push(entry);
+  }
+
+  return () => {
+    const index = shutdownHooks.findIndex(item => item.name === name);
+    if (index >= 0) {
+      shutdownHooks.splice(index, 1);
+    }
+  };
+}
+
+export async function runShutdownHooks(context: ShutdownHookContext) {
+  const results: Array<{ name: string; status: 'ok' | 'error'; error?: Error }> = [];
+  const hooks = [...shutdownHooks].reverse();
+  for (const entry of hooks) {
+    try {
+      await entry.hook(context);
+      results.push({ name: entry.name, status: 'ok' });
+    } catch (error) {
+      results.push({ name: entry.name, status: 'error', error: error as Error });
+    }
+  }
+  return results;
+}
+
+export function resetAppLifecycle() {
+  healthIndicators.splice(0, healthIndicators.length);
+  shutdownHooks.splice(0, shutdownHooks.length);
+}
+
 export async function bootstrap() {
   logger.info('Guardian bootstrap starting');
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -21,6 +21,18 @@ function extractContext(args: unknown[]): LogContext {
       const candidate = value as Record<string, unknown>;
       if (typeof candidate.detector === 'string' && candidate.detector.length > 0 && !detector) {
         detector = candidate.detector;
+      } else if (!detector) {
+        const meta = candidate.meta as Record<string, unknown> | undefined;
+        if (meta && typeof meta.detector === 'string' && meta.detector.length > 0) {
+          detector = meta.detector;
+        }
+        const context = candidate.context as Record<string, unknown> | undefined;
+        if (context && typeof context.detector === 'string' && context.detector.length > 0) {
+          detector = context.detector;
+        }
+      }
+      if (typeof candidate.message === 'string' && candidate.message.length > 0 && !message) {
+        message = candidate.message;
       }
     }
   }

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from 'node:events';
 import defaultBus from '../eventBus.js';
 import logger from '../logger.js';
 import { createEventsRouter } from './routes/events.js';
+import FaceRegistry from '../video/faceRegistry.js';
 
 export interface HttpServerOptions {
   port?: number;
@@ -26,7 +27,11 @@ export async function startHttpServer(options: HttpServerOptions = {}): Promise<
   const staticDir = options.staticDir ?? path.resolve(process.cwd(), 'public');
   const bus = options.bus ?? defaultBus;
 
-  const eventsRouter = createEventsRouter({ bus });
+  const eventsRouter = createEventsRouter({
+    bus,
+    createFaceRegistry: async () =>
+      FaceRegistry.create({ modelPath: path.resolve(process.cwd(), 'models/face.onnx') })
+  });
 
   const server = http.createServer((req, res) => {
     try {

--- a/src/video/faceRegistry.ts
+++ b/src/video/faceRegistry.ts
@@ -1,0 +1,198 @@
+import * as ort from 'onnxruntime-node';
+import { PNG } from 'pngjs';
+import logger from '../logger.js';
+import metrics from '../metrics/index.js';
+import {
+  FaceMatchResult,
+  FaceRecord,
+  deleteFace as deleteFaceRecord,
+  findNearestFace,
+  listFaces as listFaceRecords,
+  storeFace
+} from '../db.js';
+
+export interface FaceRegistryOptions {
+  modelPath: string;
+  embeddingSize?: number;
+}
+
+type InferenceSessionLike = {
+  inputNames: string[];
+  outputNames: string[];
+  run(feeds: Record<string, ort.Tensor>): Promise<Record<string, ort.Tensor>>;
+};
+
+const DEFAULT_EMBEDDING_SIZE = 128;
+
+export interface IdentifyResult {
+  embedding: number[];
+  match: FaceMatchResult | null;
+}
+
+export class FaceRegistry {
+  private session: InferenceSessionLike | null = null;
+  private inputName: string | null = null;
+  private outputName: string | null = null;
+  private readonly embeddingSize: number;
+
+  private constructor(private readonly options: FaceRegistryOptions) {
+    this.embeddingSize = options.embeddingSize ?? DEFAULT_EMBEDDING_SIZE;
+  }
+
+  static async create(options: FaceRegistryOptions) {
+    const registry = new FaceRegistry(options);
+    await registry.ensureSession();
+    return registry;
+  }
+
+  async enroll(image: Buffer, label: string, metadata?: Record<string, unknown>): Promise<FaceRecord> {
+    metrics.incrementDetectorCounter('face', 'enrollments');
+    const embedding = await this.extractEmbedding(image);
+    if (embedding.length === 0) {
+      metrics.recordDetectorError('face', 'empty-embedding');
+    }
+    const normalized = normalizeVector(embedding, this.embeddingSize);
+    return storeFace({ label, embedding: normalized, metadata });
+  }
+
+  async identify(image: Buffer, threshold: number): Promise<IdentifyResult> {
+    metrics.incrementDetectorCounter('face', 'identifications');
+    const embedding = await this.extractEmbedding(image);
+    if (embedding.length === 0) {
+      metrics.recordDetectorError('face', 'empty-embedding');
+    }
+    const normalized = normalizeVector(embedding, this.embeddingSize);
+    const match = findNearestFace(normalized, threshold);
+    if (match) {
+      metrics.incrementDetectorCounter('face', 'matches');
+    } else {
+      metrics.incrementDetectorCounter('face', 'misses');
+    }
+    return { embedding: normalized, match };
+  }
+
+  list(): FaceRecord[] {
+    return listFaceRecords();
+  }
+
+  remove(id: number): boolean {
+    const removed = deleteFaceRecord(id);
+    if (removed) {
+      metrics.incrementDetectorCounter('face', 'removals');
+    }
+    return removed;
+  }
+
+  private async extractEmbedding(image: Buffer): Promise<number[]> {
+    await this.ensureSession();
+    metrics.incrementDetectorCounter('face', 'embeddingRuns');
+    if (!this.session || !this.inputName || !this.outputName) {
+      metrics.recordDetectorError('face', 'session-unavailable');
+      return [];
+    }
+
+    const tensor = preprocessImage(image);
+    const feeds: Record<string, ort.Tensor> = {
+      [this.inputName]: tensor
+    };
+
+    let result: Record<string, ort.Tensor>;
+    try {
+      result = await this.session.run(feeds);
+    } catch (error) {
+      metrics.recordDetectorError('face', (error as Error).message ?? 'embedding-failed');
+      throw error;
+    }
+    const output = result[this.outputName];
+
+    if (!output) {
+      metrics.recordDetectorError('face', 'missing-output');
+      return [];
+    }
+
+    const data = output.data as Float32Array | number[] | undefined;
+    if (!data) {
+      metrics.recordDetectorError('face', 'empty-output');
+      return [];
+    }
+
+    return Array.from(data).map(value => Number(value));
+  }
+
+  private async ensureSession() {
+    if (this.session) {
+      return;
+    }
+
+    try {
+      const session = await ort.InferenceSession.create(this.options.modelPath);
+      this.session = session as InferenceSessionLike;
+    } catch (error) {
+      logger.warn({ err: error, modelPath: this.options.modelPath }, 'Falling back to mock face embedding session');
+      this.session = createMockSession(this.embeddingSize);
+    }
+
+    this.inputName = this.session.inputNames[0] ?? null;
+    this.outputName = this.session.outputNames[0] ?? null;
+  }
+}
+
+function preprocessImage(image: Buffer) {
+  const png = PNG.sync.read(image);
+  const { width, height, data } = png;
+  const size = width * height;
+  const channels = 3;
+  const chw = new Float32Array(size * channels);
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const srcIndex = (y * width + x) * 4;
+      const destIndex = y * width + x;
+      const r = data[srcIndex] / 255;
+      const g = data[srcIndex + 1] / 255;
+      const b = data[srcIndex + 2] / 255;
+      chw[destIndex] = r;
+      chw[size + destIndex] = g;
+      chw[2 * size + destIndex] = b;
+    }
+  }
+
+  return new ort.Tensor('float32', chw, [1, channels, height, width]);
+}
+
+function normalizeVector(values: number[], size: number) {
+  if (values.length < size) {
+    const padded = new Array(size).fill(0);
+    values.forEach((value, index) => {
+      padded[index] = value;
+    });
+    values = padded;
+  } else if (values.length > size) {
+    values = values.slice(0, size);
+  }
+
+  const length = Math.sqrt(values.reduce((acc, value) => acc + value * value, 0));
+  if (!Number.isFinite(length) || length === 0) {
+    return values.map(() => 0);
+  }
+
+  return values.map(value => value / length);
+}
+
+function createMockSession(embeddingSize: number): InferenceSessionLike {
+  return {
+    inputNames: ['image'],
+    outputNames: ['embedding'],
+    async run() {
+      const data = new Float32Array(embeddingSize);
+      for (let i = 0; i < embeddingSize; i += 1) {
+        data[i] = (i + 1) / embeddingSize;
+      }
+      return {
+        embedding: new ort.Tensor('float32', data, [1, embeddingSize])
+      };
+    }
+  };
+}
+
+export default FaceRegistry;

--- a/src/video/objectClassifier.ts
+++ b/src/video/objectClassifier.ts
@@ -1,0 +1,218 @@
+import * as ort from 'onnxruntime-node';
+import logger from '../logger.js';
+import metrics from '../metrics/index.js';
+import { YoloDetection } from './yoloParser.js';
+
+export interface ObjectClassifierOptions {
+  modelPath: string;
+  labels: string[];
+  threatLabels?: string[];
+  threatThreshold?: number;
+}
+
+type InferenceSessionLike = {
+  inputNames: string[];
+  outputNames: string[];
+  run(feeds: Record<string, ort.Tensor>): Promise<Record<string, ort.Tensor>>;
+};
+
+export interface ClassifiedObject {
+  detection: YoloDetection;
+  label: string;
+  score: number;
+  probabilities: Record<string, number>;
+  threatScore: number;
+  isThreat: boolean;
+}
+
+const DEFAULT_THREAT_THRESHOLD = 0.6;
+
+export class ObjectClassifier {
+  private session: InferenceSessionLike | null = null;
+  private inputName: string | null = null;
+  private outputName: string | null = null;
+  private readonly threatLabels: Set<string>;
+  private readonly threatThreshold: number;
+
+  private constructor(private readonly options: ObjectClassifierOptions) {
+    this.threatLabels = new Set(options.threatLabels ?? ['threat']);
+    this.threatThreshold = options.threatThreshold ?? DEFAULT_THREAT_THRESHOLD;
+  }
+
+  static async create(options: ObjectClassifierOptions) {
+    const classifier = new ObjectClassifier(options);
+    await classifier.ensureSession();
+    return classifier;
+  }
+
+  async classify(detections: YoloDetection[]): Promise<ClassifiedObject[]> {
+    if (detections.length === 0) {
+      return [];
+    }
+
+    metrics.incrementDetectorCounter('object', 'invocations');
+    metrics.incrementDetectorCounter('object', 'detections', detections.length);
+
+    await this.ensureSession();
+    if (!this.session || !this.inputName || !this.outputName) {
+      metrics.recordDetectorError('object', 'session-unavailable');
+      return [];
+    }
+
+    const features = buildFeatureTensor(detections);
+    const feeds: Record<string, ort.Tensor> = {
+      [this.inputName]: features
+    };
+
+    let results: Record<string, ort.Tensor>;
+    try {
+      results = await this.session.run(feeds);
+    } catch (error) {
+      metrics.recordDetectorError('object', (error as Error).message ?? 'inference-failed');
+      logger.error({ err: error }, 'Object classifier inference failed');
+      return [];
+    }
+
+    const output = results[this.outputName];
+    if (!output) {
+      metrics.recordDetectorError('object', 'missing-output');
+      return [];
+    }
+
+    const data = output.data as Float32Array | number[] | undefined;
+    if (!data) {
+      metrics.recordDetectorError('object', 'empty-output');
+      return [];
+    }
+
+    const labels = this.options.labels;
+    const labelCount = labels.length;
+    const scores = Array.from(data, value => Number(value));
+    const objects: ClassifiedObject[] = [];
+
+    for (let index = 0; index < detections.length; index += 1) {
+      const start = index * labelCount;
+      const end = start + labelCount;
+      const logits = scores.slice(start, end);
+      const probabilities = softmax(logits);
+      let bestIndex = 0;
+      let bestScore = probabilities[0] ?? 0;
+      for (let i = 1; i < probabilities.length; i += 1) {
+        if (probabilities[i] > bestScore) {
+          bestScore = probabilities[i];
+          bestIndex = i;
+        }
+      }
+
+      const probabilityMap: Record<string, number> = {};
+      for (let i = 0; i < labels.length; i += 1) {
+        probabilityMap[labels[i]] = probabilities[i] ?? 0;
+      }
+
+      const label = labels[bestIndex] ?? `class-${bestIndex}`;
+      const threatScore = this.computeThreatScore(label, probabilityMap);
+      const isThreat = threatScore >= this.threatThreshold;
+
+      objects.push({
+        detection: detections[index],
+        label,
+        score: bestScore,
+        probabilities: probabilityMap,
+        threatScore,
+        isThreat
+      });
+    }
+
+    metrics.incrementDetectorCounter('object', 'classifications', objects.length);
+    const threatCount = objects.filter(object => object.isThreat).length;
+    if (threatCount > 0) {
+      metrics.incrementDetectorCounter('object', 'threats', threatCount);
+    }
+
+    return objects;
+  }
+
+  private computeThreatScore(label: string, probabilities: Record<string, number>) {
+    if (this.threatLabels.has(label)) {
+      return probabilities[label] ?? 0;
+    }
+
+    let maxThreat = 0;
+    for (const threat of this.threatLabels) {
+      const score = probabilities[threat];
+      if (typeof score === 'number' && score > maxThreat) {
+        maxThreat = score;
+      }
+    }
+    return maxThreat;
+  }
+
+  private async ensureSession() {
+    if (this.session) {
+      return;
+    }
+
+    try {
+      const session = await ort.InferenceSession.create(this.options.modelPath);
+      this.session = session as InferenceSessionLike;
+    } catch (error) {
+      logger.warn({ err: error, modelPath: this.options.modelPath }, 'Falling back to mock object classifier');
+      this.session = createMockSession(this.options.labels.length);
+    }
+
+    this.inputName = this.session.inputNames[0] ?? null;
+    this.outputName = this.session.outputNames[0] ?? null;
+  }
+}
+
+function buildFeatureTensor(detections: YoloDetection[]) {
+  const featureCount = 5;
+  const data = new Float32Array(detections.length * featureCount);
+
+  for (let i = 0; i < detections.length; i += 1) {
+    const detection = detections[i];
+    const base = i * featureCount;
+    data[base] = detection.score;
+    data[base + 1] = detection.areaRatio;
+    data[base + 2] = detection.bbox.width;
+    data[base + 3] = detection.bbox.height;
+    data[base + 4] = detection.classId;
+  }
+
+  return new ort.Tensor('float32', data, [detections.length, featureCount]);
+}
+
+function softmax(values: number[]): number[] {
+  if (values.length === 0) {
+    return [];
+  }
+
+  const max = Math.max(...values);
+  const expValues = values.map(value => Math.exp(value - max));
+  const sum = expValues.reduce((acc, value) => acc + value, 0);
+  if (sum === 0) {
+    return values.map(() => 0);
+  }
+  return expValues.map(value => value / sum);
+}
+
+function createMockSession(labelCount: number): InferenceSessionLike {
+  return {
+    inputNames: ['features'],
+    outputNames: ['logits'],
+    async run(feeds) {
+      const input = Object.values(feeds)[0];
+      const detections = input ? input.dims?.[0] ?? 1 : 1;
+      const total = Math.max(1, detections * Math.max(1, labelCount));
+      const data = new Float32Array(total);
+      for (let i = 0; i < total; i += 1) {
+        data[i] = i % labelCount === labelCount - 1 ? 2 : 0.2;
+      }
+      return {
+        logits: new ort.Tensor('float32', data, [detections, Math.max(1, labelCount)])
+      };
+    }
+  };
+}
+
+export default ObjectClassifier;

--- a/src/video/poseEstimator.ts
+++ b/src/video/poseEstimator.ts
@@ -1,0 +1,251 @@
+import { EventEmitter } from 'node:events';
+import { performance } from 'node:perf_hooks';
+import * as ort from 'onnxruntime-node';
+import eventBus from '../eventBus.js';
+import logger from '../logger.js';
+import metrics from '../metrics/index.js';
+import { EventPayload } from '../types.js';
+
+export type PoseKeypoint = {
+  x: number;
+  y: number;
+  z?: number;
+  confidence?: number;
+};
+
+export type PoseFrame = {
+  ts: number;
+  keypoints: PoseKeypoint[];
+};
+
+export type PoseForecast = {
+  horizonMs: number;
+  velocity: number[];
+  acceleration: number[];
+  movementFlags: boolean[];
+  confidence: number;
+};
+
+export interface PoseEstimatorOptions {
+  source: string;
+  modelPath: string;
+  forecastHorizonMs?: number;
+  smoothingWindow?: number;
+  minMovement?: number;
+  historySize?: number;
+  bus?: EventEmitter;
+}
+
+type InferenceSessionLike = {
+  inputNames: string[];
+  outputNames: string[];
+  run(feeds: Record<string, ort.Tensor>): Promise<Record<string, ort.Tensor>>;
+};
+
+const DEFAULT_HORIZON_MS = 1500;
+const DEFAULT_SMOOTHING = 3;
+const DEFAULT_MIN_MOVEMENT = 0.1;
+const DEFAULT_HISTORY = 12;
+
+export class PoseEstimator {
+  private session: InferenceSessionLike | null = null;
+  private inputName: string | null = null;
+  private outputName: string | null = null;
+  private readonly history: PoseFrame[] = [];
+  private readonly bus: EventEmitter;
+  private lastForecast: PoseForecast | null = null;
+
+  private constructor(private readonly options: PoseEstimatorOptions) {
+    this.bus = options.bus ?? eventBus;
+  }
+
+  static async create(options: PoseEstimatorOptions) {
+    const estimator = new PoseEstimator(options);
+    await estimator.ensureSession();
+    return estimator;
+  }
+
+  ingest(frame: PoseFrame) {
+    const maxHistory = this.options.historySize ?? DEFAULT_HISTORY;
+    this.history.push(frame);
+    while (this.history.length > maxHistory) {
+      this.history.shift();
+    }
+  }
+
+  async forecast(motionMeta: Record<string, unknown> | undefined, ts = Date.now()) {
+    const start = performance.now();
+    metrics.incrementDetectorCounter('pose', 'invocations');
+    try {
+      await this.ensureSession();
+      if (!this.session || !this.inputName || !this.outputName) {
+        metrics.recordDetectorError('pose', 'session-unavailable');
+        return null;
+      }
+
+      const window = this.options.smoothingWindow ?? DEFAULT_SMOOTHING;
+      const history = this.history.slice(-Math.max(window, 1));
+
+      if (history.length === 0) {
+        metrics.incrementDetectorCounter('pose', 'skipped');
+        return null;
+      }
+
+      const tensor = buildPoseTensor(history);
+      const feeds: Record<string, ort.Tensor> = {
+        [this.inputName]: tensor
+      };
+
+      const results = await this.session.run(feeds);
+      const output = results[this.outputName];
+
+      if (!output) {
+        metrics.recordDetectorError('pose', 'missing-output');
+        return null;
+      }
+
+      const forecast = interpretForecast(output, {
+        horizonMs: this.options.forecastHorizonMs ?? DEFAULT_HORIZON_MS,
+        minMovement: this.options.minMovement ?? DEFAULT_MIN_MOVEMENT
+      });
+
+      this.lastForecast = forecast;
+      metrics.incrementDetectorCounter('pose', 'forecasts');
+      metrics.incrementDetectorCounter('pose', 'frames', history.length);
+      const movementCount = forecast.movementFlags.filter(Boolean).length;
+      if (movementCount > 0) {
+        metrics.incrementDetectorCounter('pose', 'movementFlags', movementCount);
+      }
+
+      const payload: EventPayload = {
+        ts,
+        source: this.options.source,
+        detector: 'pose',
+        severity: 'info',
+        message: 'Pose forecast generated',
+        meta: {
+          horizonMs: forecast.horizonMs,
+          velocity: forecast.velocity,
+          acceleration: forecast.acceleration,
+          movementFlags: forecast.movementFlags,
+          confidence: forecast.confidence,
+          motion: motionMeta,
+          frames: history.map(frame => ({ ts: frame.ts, keypoints: frame.keypoints.length }))
+        }
+      };
+
+      this.bus.emit('event', payload);
+      return forecast;
+    } catch (error) {
+      metrics.recordDetectorError('pose', (error as Error).message ?? 'forecast-failed');
+      throw error;
+    } finally {
+      metrics.observeDetectorLatency('pose', performance.now() - start);
+    }
+  }
+
+  mergeIntoMotionMeta(meta: Record<string, unknown> | undefined) {
+    if (!this.lastForecast) {
+      return meta;
+    }
+    const merged = { ...(meta ?? {}), poseForecast: this.lastForecast };
+    return merged;
+  }
+
+  private async ensureSession() {
+    if (this.session) {
+      return;
+    }
+
+    try {
+      const session = await ort.InferenceSession.create(this.options.modelPath);
+      this.session = session as InferenceSessionLike;
+    } catch (error) {
+      logger.warn({ err: error, modelPath: this.options.modelPath }, 'Falling back to mock pose estimator');
+      this.session = createMockSession();
+    }
+
+    this.inputName = this.session.inputNames[0] ?? null;
+    this.outputName = this.session.outputNames[0] ?? null;
+  }
+}
+
+function buildPoseTensor(history: PoseFrame[]) {
+  const joints = history[0]?.keypoints.length ?? 0;
+  const features = 4; // x, y, z, confidence
+  const frames = history.length;
+  const data = new Float32Array(frames * joints * features);
+
+  for (let frameIndex = 0; frameIndex < frames; frameIndex += 1) {
+    const frame = history[frameIndex];
+    for (let jointIndex = 0; jointIndex < joints; jointIndex += 1) {
+      const keypoint = frame.keypoints[jointIndex] ?? { x: 0, y: 0, z: 0, confidence: 0 };
+      const baseIndex = frameIndex * joints * features + jointIndex * features;
+      data[baseIndex] = keypoint.x;
+      data[baseIndex + 1] = keypoint.y;
+      data[baseIndex + 2] = keypoint.z ?? 0;
+      data[baseIndex + 3] = keypoint.confidence ?? 0;
+    }
+  }
+
+  return new ort.Tensor('float32', data, [1, frames, joints, features]);
+}
+
+function interpretForecast(
+  output: ort.OnnxValue,
+  options: { horizonMs: number; minMovement: number }
+): PoseForecast {
+  const data = output.data as Float32Array | number[] | undefined;
+  if (!data || data.length === 0) {
+    return {
+      horizonMs: options.horizonMs,
+      velocity: [],
+      acceleration: [],
+      movementFlags: [],
+      confidence: 0
+    };
+  }
+
+  const values = Array.from(data, value => roundFloat(Number(value)));
+  const joints = Math.floor(values.length / 2);
+  const velocity = values.slice(0, joints);
+  const acceleration = values.slice(joints);
+
+  const movementFlags = velocity.map((value, index) => {
+    const accel = Math.abs(acceleration[index] ?? 0);
+    return Math.abs(value) + accel > options.minMovement;
+  });
+
+  const confidence = movementFlags.reduce((acc, flag) => acc + (flag ? 1 : 0), 0) / (movementFlags.length || 1);
+
+  return {
+    horizonMs: options.horizonMs,
+    velocity,
+    acceleration,
+    movementFlags,
+    confidence
+  };
+}
+
+function createMockSession(): InferenceSessionLike {
+  return {
+    inputNames: ['poses'],
+    outputNames: ['forecast'],
+    async run() {
+      const data = new Float32Array([0.05, 0.12, 0.03, 0.08, 0.01, 0.02]);
+      return {
+        forecast: new ort.Tensor('float32', data, [1, data.length])
+      };
+    }
+  };
+}
+
+function roundFloat(value: number, precision = 6) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+export default PoseEstimator;

--- a/tests/audio_anomaly.test.ts
+++ b/tests/audio_anomaly.test.ts
@@ -100,14 +100,17 @@ describe('AudioAnomalyAdaptiveWindow', () => {
     expect(events).toHaveLength(1);
     expect(events[0].detector).toBe('audio-anomaly');
     expect(events[0].meta?.triggeredBy).toBe('rms');
-    expect(Number(events[0].meta?.durationAboveThresholdMs)).toBeGreaterThanOrEqual(100);
+    expect(Number(events[0].meta?.durationAboveThresholdMs)).toBeGreaterThanOrEqual(hopDurationMs);
     const windowMeta = events[0].meta?.window as Record<string, number>;
     expect(Number(windowMeta?.frameDurationMs)).toBeCloseTo(frameDurationMs, 3);
     expect(Number(windowMeta?.hopDurationMs)).toBeCloseTo(hopDurationMs, 3);
+    expect(Number(windowMeta?.processedFrames ?? 0)).toBeGreaterThanOrEqual(2);
     const thresholds = events[0].meta?.thresholds as Record<string, number>;
     expect(Number(thresholds?.rms)).toBeCloseTo(0.4, 3);
     const baselines = events[0].meta?.baselines as Record<string, number>;
     expect(Number(baselines?.rms)).toBeLessThan(Number(events[0].meta?.rms));
+    const accumulation = events[0].meta?.accumulationMs as Record<string, number>;
+    expect(Number(accumulation?.rmsMs ?? 0)).toBeGreaterThan(0);
   });
 
   it('AudioAnomalyAdaptiveWindow applies night thresholds to centroid jumps', () => {
@@ -143,6 +146,8 @@ describe('AudioAnomalyAdaptiveWindow', () => {
     expect(events[0].meta?.triggeredBy).toBe('centroid');
     const thresholds = events[0].meta?.thresholds as Record<string, number>;
     expect(Number(thresholds?.centroidJump)).toBeCloseTo(40, 3);
+    const accumulation = events[0].meta?.accumulationMs as Record<string, number>;
+    expect(Number(accumulation?.centroidMs ?? 0)).toBeGreaterThanOrEqual(0);
   });
 });
 

--- a/tests/face_registry.test.ts
+++ b/tests/face_registry.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PNG } from 'pngjs';
+import FaceRegistry from '../src/video/faceRegistry.js';
+import { clearFaces } from '../src/db.js';
+
+const runMock = vi.fn();
+
+vi.mock('onnxruntime-node', () => {
+  class Tensor<T> {
+    constructor(
+      public readonly type: string,
+      public readonly data: T,
+      public readonly dims: number[]
+    ) {}
+  }
+
+  return {
+    InferenceSession: {
+      create: vi.fn(async () => ({
+        inputNames: ['image'],
+        outputNames: ['embedding'],
+        run: runMock
+      }))
+    },
+    Tensor
+  };
+});
+
+const ort = await import('onnxruntime-node');
+
+describe('FaceRegistryEnrollment', () => {
+  beforeEach(() => {
+    clearFaces();
+    runMock.mockReset();
+  });
+
+  afterEach(() => {
+    clearFaces();
+  });
+
+  it('enrolls faces, matches by distance, and rejects distant embeddings', async () => {
+    const registry = await FaceRegistry.create({ modelPath: 'models/face.onnx', embeddingSize: 4 });
+
+    const faceImageA = createSolidFace([220, 190, 180]);
+    const faceImageB = createSolidFace([80, 120, 160]);
+
+    runMock.mockResolvedValueOnce({
+      embedding: new ort.Tensor('float32', new Float32Array([0.3, 0.4, 0.5, 0.6]), [1, 4])
+    });
+    const alice = await registry.enroll(faceImageA, 'Alice', { group: 'staff' });
+    expect(alice.label).toBe('Alice');
+    expect(alice.metadata?.group).toBe('staff');
+
+    runMock.mockResolvedValueOnce({
+      embedding: new ort.Tensor('float32', new Float32Array([0.9, 0.1, 0.05, 0.02]), [1, 4])
+    });
+    const bob = await registry.enroll(faceImageB, 'Bob');
+    expect(bob.id).not.toBe(alice.id);
+
+    expect(registry.list()).toHaveLength(2);
+
+    runMock.mockResolvedValueOnce({
+      embedding: new ort.Tensor('float32', new Float32Array([0.31, 0.41, 0.52, 0.61]), [1, 4])
+    });
+    const match = await registry.identify(faceImageA, 0.25);
+    expect(match.match?.face.label).toBe('Alice');
+    expect(match.match?.distance).toBeLessThan(0.25);
+
+    runMock.mockResolvedValueOnce({
+      embedding: new ort.Tensor('float32', new Float32Array([0.1, 0.8, 0.1, 0.5]), [1, 4])
+    });
+    const miss = await registry.identify(faceImageA, 0.15);
+    expect(miss.match).toBeNull();
+
+    const removed = registry.remove(alice.id);
+    expect(removed).toBe(true);
+    expect(registry.list()).toHaveLength(1);
+  });
+});
+
+function createSolidFace(color: [number, number, number]) {
+  const png = new PNG({ width: 4, height: 4 });
+  for (let y = 0; y < png.height; y += 1) {
+    for (let x = 0; x < png.width; x += 1) {
+      const idx = (png.width * y + x) << 2;
+      png.data[idx] = color[0];
+      png.data[idx + 1] = color[1];
+      png.data[idx + 2] = color[2];
+      png.data[idx + 3] = 255;
+    }
+  }
+  return PNG.sync.write(png);
+}

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -137,4 +137,38 @@ describe('MetricsCounters', () => {
     expect(snapshot.suppression.rules['rule-2'].total).toBe(1);
     expect(snapshot.suppression.rules['rule-2'].byReason['rate-limit']).toBe(1);
   });
+
+  it('MetricsDetectorCounters tracks pose, face and object detector counters', () => {
+    const registry = new MetricsRegistry();
+
+    registry.incrementDetectorCounter('pose', 'forecasts');
+    registry.incrementDetectorCounter('pose', 'forecasts', 2);
+    registry.recordDetectorError('pose', 'forecast-failed');
+
+    registry.incrementDetectorCounter('face', 'enrollments', 3);
+    registry.incrementDetectorCounter('face', 'matches');
+    registry.incrementDetectorCounter('face', 'misses', 2);
+    registry.recordDetectorError('face', 'empty-embedding');
+
+    registry.incrementDetectorCounter('object', 'classifications', 5);
+    registry.incrementDetectorCounter('object', 'threats', 2);
+    registry.incrementDetectorCounter('object', 'detections', 7);
+
+    const snapshot = registry.snapshot();
+
+    expect(snapshot.detectors.pose.counters.forecasts).toBe(3);
+    expect(snapshot.detectors.pose.counters.errors).toBe(1);
+    expect(snapshot.detectors.pose.lastErrorMessage).toBe('forecast-failed');
+
+    expect(snapshot.detectors.face.counters.enrollments).toBe(3);
+    expect(snapshot.detectors.face.counters.matches).toBe(1);
+    expect(snapshot.detectors.face.counters.misses).toBe(2);
+    expect(snapshot.detectors.face.counters.errors).toBe(1);
+    expect(snapshot.detectors.face.lastErrorMessage).toBe('empty-embedding');
+
+    expect(snapshot.detectors.object.counters.classifications).toBe(5);
+    expect(snapshot.detectors.object.counters.threats).toBe(2);
+    expect(snapshot.detectors.object.counters.detections).toBe(7);
+    expect(snapshot.detectors.object.lastRunAt).not.toBeNull();
+  });
 });

--- a/tests/object_classifier.test.ts
+++ b/tests/object_classifier.test.ts
@@ -1,0 +1,219 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { EventEmitter } from 'node:events';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import ObjectClassifier from '../src/video/objectClassifier.js';
+import PersonDetector from '../src/video/personDetector.js';
+import { YOLO_CLASS_START_INDEX } from '../src/video/yoloParser.js';
+
+const runMocks = new Map<string, ReturnType<typeof vi.fn>>();
+
+vi.mock('onnxruntime-node', () => {
+  class Tensor<T> {
+    constructor(
+      public readonly type: string,
+      public readonly data: T,
+      public readonly dims: number[]
+    ) {}
+  }
+
+  const create = vi.fn(async (modelPath: string) => {
+    const run = runMocks.get(modelPath) ?? vi.fn(async () => ({}));
+    const inputNames = modelPath.includes('object') ? ['features'] : ['images'];
+    const outputNames = modelPath.includes('object') ? ['logits'] : ['output0'];
+    return {
+      inputNames,
+      outputNames,
+      run
+    };
+  });
+
+  return {
+    InferenceSession: { create },
+    Tensor,
+    __setRunMock(modelPath: string, run: ReturnType<typeof vi.fn>) {
+      runMocks.set(modelPath, run);
+    }
+  };
+});
+
+vi.mock('pngjs', () => {
+  const store = new WeakMap<Buffer, { width: number; height: number; data: Uint8Array }>();
+
+  class FakePNG {
+    width: number;
+    height: number;
+    data: Uint8Array;
+
+    constructor({ width, height }: { width: number; height: number }) {
+      this.width = width;
+      this.height = height;
+      this.data = new Uint8Array(width * height * 4);
+    }
+
+    static sync = {
+      write(png: FakePNG) {
+        const buffer = Buffer.from(png.data);
+        store.set(buffer, {
+          width: png.width,
+          height: png.height,
+          data: Uint8Array.from(png.data)
+        });
+        return buffer;
+      },
+      read(buffer: Buffer) {
+        const entry = store.get(buffer);
+        if (!entry) {
+          throw new Error('Unknown buffer');
+        }
+        const png = new FakePNG({ width: entry.width, height: entry.height });
+        png.data.set(entry.data);
+        return png;
+      }
+    };
+  }
+
+  return { PNG: FakePNG };
+});
+
+const ort = await import('onnxruntime-node');
+const setRunMock = (ort as unknown as { __setRunMock: (modelPath: string, run: ReturnType<typeof vi.fn>) => void }).__setRunMock;
+const Tensor = ort.Tensor as typeof import('onnxruntime-node').Tensor;
+const { PNG } = await import('pngjs');
+
+describe('ObjectClassifierThreatTag', () => {
+  const snapshotsDir = path.resolve('snapshots');
+  beforeEach(() => {
+    runMocks.clear();
+    if (fs.existsSync(snapshotsDir)) {
+      fs.rmSync(snapshotsDir, { recursive: true, force: true });
+    }
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(snapshotsDir)) {
+      fs.rmSync(snapshotsDir, { recursive: true, force: true });
+    }
+  });
+
+  it('annotates person events with classified threat metadata', async () => {
+    const detectionRun = vi.fn(async () => {
+      const classCount = 3;
+      const attributes = YOLO_CLASS_START_INDEX + classCount;
+      const detections = 2;
+      const data = new Float32Array(attributes * detections).fill(0);
+
+      setDetection(data, detections, 0, {
+        cx: 320,
+        cy: 240,
+        width: 220,
+        height: 260,
+        objectnessLogit: 2.5,
+        personLogit: 2.3,
+        class1Logit: -4,
+        class2Logit: -3
+      });
+
+      setDetection(data, detections, 1, {
+        cx: 400,
+        cy: 250,
+        width: 180,
+        height: 210,
+        objectnessLogit: 1.9,
+        personLogit: -4,
+        class1Logit: 2.4,
+        class2Logit: -3
+      });
+
+      return {
+        output0: { data, dims: [1, attributes, detections] }
+      };
+    });
+
+    const classifierRun = vi.fn(async () => {
+      const logits = new Float32Array([0.2, 0.4, 2.1]);
+      return {
+        logits: new Tensor('float32', logits, [1, 3])
+      };
+    });
+
+    setRunMock('models/yolov8n.onnx', detectionRun);
+    setRunMock('models/object.onnx', classifierRun);
+
+    const objectClassifier = await ObjectClassifier.create({
+      modelPath: 'models/object.onnx',
+      labels: ['pet', 'delivery', 'threat'],
+      threatLabels: ['threat'],
+      threatThreshold: 0.6
+    });
+
+    const bus = new EventEmitter();
+    const events: any[] = [];
+    bus.on('event', payload => events.push(payload));
+
+    const detector = await PersonDetector.create(
+      {
+        source: 'video:test-object',
+        modelPath: 'models/yolov8n.onnx',
+        scoreThreshold: 0.3,
+        snapshotDir: 'snapshots',
+        minIntervalMs: 0,
+        classIndices: [0, 1, 2],
+        objectClassifier
+      },
+      bus
+    );
+
+    const frame = createUniformFrame(640, 480, 120);
+    await detector.handleFrame(frame, 10);
+
+    expect(events).toHaveLength(1);
+    const meta = events[0].meta as Record<string, unknown>;
+    const objects = meta.objects as Array<Record<string, unknown>>;
+    expect(Array.isArray(objects)).toBe(true);
+    expect(objects).toHaveLength(1);
+    expect(objects[0].label).toBe('threat');
+    expect(objects[0].threat).toBe(true);
+    expect(objects[0].threatScore).toBeGreaterThan(0.6);
+    expect((meta.threat as Record<string, unknown>).label).toBe('threat');
+  });
+});
+
+function setDetection(
+  data: Float32Array,
+  detections: number,
+  index: number,
+  values: {
+    cx: number;
+    cy: number;
+    width: number;
+    height: number;
+    objectnessLogit: number;
+    personLogit: number;
+    class1Logit: number;
+    class2Logit: number;
+  }
+) {
+  data[0 * detections + index] = values.cx;
+  data[1 * detections + index] = values.cy;
+  data[2 * detections + index] = values.width;
+  data[3 * detections + index] = values.height;
+  data[4 * detections + index] = values.objectnessLogit;
+  data[5 * detections + index] = values.personLogit;
+  data[6 * detections + index] = values.class1Logit;
+  data[7 * detections + index] = values.class2Logit;
+}
+
+function createUniformFrame(width: number, height: number, value: number) {
+  const png = new PNG({ width, height });
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const idx = (width * y + x) << 2;
+      png.data[idx] = value;
+      png.data[idx + 1] = value;
+      png.data[idx + 2] = value;
+      png.data[idx + 3] = 255;
+    }
+  }
+  return PNG.sync.write(png);
+}

--- a/tests/pose_estimator.test.ts
+++ b/tests/pose_estimator.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import PoseEstimator, { PoseFrame } from '../src/video/poseEstimator.js';
+
+const runMock = vi.fn();
+
+vi.mock('onnxruntime-node', () => {
+  class Tensor<T> {
+    constructor(
+      public readonly type: string,
+      public readonly data: T,
+      public readonly dims: number[]
+    ) {}
+  }
+
+  return {
+    InferenceSession: {
+      create: vi.fn(async () => ({
+        inputNames: ['poses'],
+        outputNames: ['forecast'],
+        run: runMock
+      }))
+    },
+    Tensor
+  };
+});
+
+const ort = await import('onnxruntime-node');
+
+describe('PoseEstimatorForecast', () => {
+  beforeEach(() => {
+    runMock.mockReset();
+  });
+
+  it('generates forecast events from pose history and motion metadata', async () => {
+    const bus = new EventEmitter();
+    const events: unknown[] = [];
+    bus.on('event', event => {
+      events.push(event);
+    });
+
+    const horizon = 900;
+    const estimator = await PoseEstimator.create({
+      source: 'video:test-pose',
+      modelPath: 'models/pose.onnx',
+      forecastHorizonMs: horizon,
+      smoothingWindow: 3,
+      minMovement: 0.05,
+      bus
+    });
+
+    const tensorData = new Float32Array([0.1, 0.05, -0.02, 0.02, 0.03, 0.01]);
+    runMock.mockResolvedValueOnce({
+      forecast: new ort.Tensor('float32', tensorData, [1, tensorData.length])
+    });
+
+    const frames: PoseFrame[] = [
+      { ts: 1, keypoints: buildKeypoints([0.1, 0.2, 0.3]) },
+      { ts: 2, keypoints: buildKeypoints([0.15, 0.25, 0.35]) },
+      { ts: 3, keypoints: buildKeypoints([0.2, 0.3, 0.4]) }
+    ];
+    frames.forEach(frame => estimator.ingest(frame));
+
+    const motionMeta = { areaPct: 0.18, diffThreshold: 12 } as Record<string, unknown>;
+    const forecast = await estimator.forecast(motionMeta, 42);
+
+    expect(forecast).not.toBeNull();
+    const resolved = forecast!;
+    expect(resolved.horizonMs).toBe(horizon);
+    expect(resolved.velocity).toEqual([0.1, 0.05, -0.02]);
+    expect(resolved.acceleration).toEqual([0.02, 0.03, 0.01]);
+    expect(resolved.movementFlags).toEqual([true, true, false]);
+    expect(resolved.confidence).toBeCloseTo(2 / 3, 5);
+
+    expect(events).toHaveLength(1);
+    const event = events[0] as {
+      detector: string;
+      meta?: Record<string, unknown>;
+    };
+    expect(event.detector).toBe('pose');
+    expect(event.meta?.horizonMs).toBe(horizon);
+    expect(event.meta?.movementFlags).toEqual([true, true, false]);
+    expect(event.meta?.motion).toEqual(motionMeta);
+    expect(Array.isArray(event.meta?.frames)).toBe(true);
+    expect((event.meta?.frames as unknown[]).length).toBe(3);
+
+    const merged = estimator.mergeIntoMotionMeta({
+      existing: true
+    });
+    expect(merged?.poseForecast).toMatchObject({
+      horizonMs: horizon,
+      movementFlags: [true, true, false]
+    });
+  });
+});
+
+function buildKeypoints(values: number[]) {
+  return values.map(value => ({ x: value, y: value + 0.05, z: value / 2, confidence: 0.9 }));
+}

--- a/tests/stubs/onnxruntime-node.ts
+++ b/tests/stubs/onnxruntime-node.ts
@@ -1,0 +1,39 @@
+export type TypedArray = Float32Array | Float64Array | Int32Array | BigInt64Array | number[];
+
+export class Tensor<T extends TypedArray = Float32Array> {
+  constructor(
+    public readonly type: string,
+    public readonly data: T,
+    public readonly dims: number[]
+  ) {}
+}
+
+export interface OnnxValue {
+  data?: TypedArray;
+  dims?: number[];
+}
+
+export interface InferenceSessionLike {
+  inputNames: string[];
+  outputNames: string[];
+  run(feeds: Record<string, Tensor>): Promise<Record<string, Tensor>>;
+}
+
+function missingModelError(modelPath: string) {
+  const error = new Error(
+    `Load model from ${modelPath} failed: Load model ${modelPath} failed. File doesn't exist`
+  ) as NodeJS.ErrnoException;
+  error.code = 'ENOENT';
+  return error;
+}
+
+export const InferenceSession = {
+  async create(modelPath: string): Promise<InferenceSessionLike> {
+    throw missingModelError(modelPath);
+  }
+};
+
+export default {
+  Tensor,
+  InferenceSession
+};

--- a/tests/stubs/pngjs.ts
+++ b/tests/stubs/pngjs.ts
@@ -1,0 +1,37 @@
+class StubPNG {
+  width: number;
+  height: number;
+  data: Uint8Array;
+
+  constructor({ width, height }: { width: number; height: number }) {
+    this.width = width;
+    this.height = height;
+    this.data = new Uint8Array(width * height * 4);
+  }
+
+  static sync = {
+    write(png: StubPNG) {
+      const header = Buffer.alloc(8);
+      header.writeUInt32BE(png.width, 0);
+      header.writeUInt32BE(png.height, 4);
+      return Buffer.concat([header, Buffer.from(png.data)]);
+    },
+    read(buffer: Buffer) {
+      if (buffer.length < 8) {
+        throw new Error('Invalid PNG buffer');
+      }
+      const width = buffer.readUInt32BE(0);
+      const height = buffer.readUInt32BE(4);
+      const data = new Uint8Array(buffer.subarray(8));
+      if (data.length < width * height * 4) {
+        const padded = new Uint8Array(width * height * 4);
+        padded.set(data);
+        return { width, height, data: padded };
+      }
+      return { width, height, data };
+    }
+  } as const;
+}
+
+export { StubPNG as PNG };
+export default { PNG: StubPNG };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,13 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      'onnxruntime-node': path.resolve(__dirname, 'tests/stubs/onnxruntime-node.ts'),
+      pngjs: path.resolve(__dirname, 'tests/stubs/pngjs.ts')
+    }
+  },
   test: {
     include: ['tests/**/*.test.ts'],
     globals: true,


### PR DESCRIPTION
## Summary
- add application-level health indicators and shutdown hook registry consumed by the CLI for graceful stop handling and Docker/systemd integrations
- extend pose, face, and object detectors plus metrics registry to record detector-specific counters and errors surfaced through the CLI health payload
- document updated CLI usage, metrics, and deployment guidance while providing a systemd unit file and tightening Docker stop signalling

## Testing
- pnpm vitest run tests/cli_health.test.ts -t "CliGracefulShutdown"
- pnpm vitest run tests/metrics.test.ts -t "MetricsDetectorCounters"
- pnpm exec tsx src/cli.ts --health


------
https://chatgpt.com/codex/tasks/task_b_68d4de6559d08328af5759b63857ce35