### PR TITLE
Add audio hot reload handling and CLI JSON status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ COPY . .
 STOPSIGNAL SIGTERM
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-  CMD pnpm exec tsx src/cli.ts --health || exit 1
+  CMD pnpm exec tsx src/cli.ts status --json || exit 1
 
 CMD ["pnpm", "start"]

--- a/deploy/guardian.service
+++ b/deploy/guardian.service
@@ -10,7 +10,7 @@ Environment=GUARDIAN_DATA_DIR=/var/lib/guardian
 Environment=PATH=/usr/local/bin:/usr/bin
 WorkingDirectory=/opt/guardian
 ExecStart=/usr/bin/env pnpm start
-ExecReload=/usr/bin/env pnpm exec tsx src/cli.ts health
+ExecReload=/usr/bin/env pnpm exec tsx src/cli.ts status --json
 ExecStop=/usr/bin/env pnpm exec tsx src/cli.ts stop
 KillSignal=SIGTERM
 Restart=on-failure

--- a/public/index.html
+++ b/public/index.html
@@ -98,7 +98,8 @@
         color: #243b53;
       }
 
-      .stream-widget {
+      .stream-widget,
+      .metrics-widget {
         background: #fff;
         border-radius: 0.75rem;
         padding: 1rem 1.25rem;
@@ -106,7 +107,8 @@
         border: 1px solid #d9e2ec;
       }
 
-      .stream-widget h2 {
+      .stream-widget h2,
+      .metrics-widget h2 {
         margin: 0 0 0.75rem 0;
         font-size: 1.05rem;
         color: #243b53;
@@ -161,6 +163,59 @@
         display: grid;
         gap: 0.5rem 1rem;
         grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      }
+
+      .metrics-grid {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .metrics-section {
+        border-top: 1px solid #d9e2ec;
+        padding-top: 0.75rem;
+      }
+
+      .metrics-section:first-child {
+        border-top: none;
+        padding-top: 0;
+      }
+
+      .metrics-summary {
+        display: grid;
+        gap: 0.25rem;
+        font-size: 0.85rem;
+        color: #52606d;
+      }
+
+      .metrics-summary strong {
+        font-size: 1.05rem;
+        color: #243b53;
+      }
+
+      .metrics-channels {
+        display: grid;
+        gap: 0.4rem;
+        margin-top: 0.6rem;
+      }
+
+      .metrics-channel {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        padding: 0.4rem 0.55rem;
+        border-radius: 0.5rem;
+        background: #f0f4f8;
+        font-size: 0.85rem;
+        color: #364152;
+      }
+
+      .metrics-channel span {
+        font-weight: 600;
+        color: #243b53;
+      }
+
+      .metrics-channel small {
+        color: #52606d;
       }
 
       .stream-widget dt {
@@ -351,6 +406,16 @@
             <dt>Last update</dt>
             <dd id="stream-updated">—</dd>
           </dl>
+        </section>
+        <section
+          class="metrics-widget"
+          aria-live="polite"
+          aria-label="Pipeline and channel metrics"
+        >
+          <h2>Pipeline health</h2>
+          <div id="pipeline-metrics" class="metrics-grid" aria-live="polite">
+            <p class="meta" id="pipeline-metrics-empty">Loading metrics…</p>
+          </div>
         </section>
         <section
           id="channel-filter"

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -7,6 +7,7 @@ import defaultBus from '../eventBus.js';
 import logger from '../logger.js';
 import { createEventsRouter } from './routes/events.js';
 import FaceRegistry from '../video/faceRegistry.js';
+import metrics from '../metrics/index.js';
 
 export interface HttpServerOptions {
   port?: number;
@@ -34,7 +35,8 @@ export async function startHttpServer(options: HttpServerOptions = {}): Promise<
     faceRegistry: options.faceRegistry,
     createFaceRegistry:
       options.createFaceRegistry ??
-      (async () => FaceRegistry.create({ modelPath: path.resolve(process.cwd(), 'models/face.onnx') }))
+      (async () => FaceRegistry.create({ modelPath: path.resolve(process.cwd(), 'models/face.onnx') })),
+    metrics
   });
 
   const server = http.createServer((req, res) => {

--- a/src/tasks/retention.ts
+++ b/src/tasks/retention.ts
@@ -120,7 +120,8 @@ export class RetentionTask {
 
       const shouldVacuum =
         this.options.vacuum.run === 'always' ||
-        (this.options.vacuum.run !== 'always' && outcome.removedEvents > 0);
+        (this.options.vacuum.run !== 'always' &&
+          (outcome.removedEvents > 0 || outcome.archivedSnapshots > 0 || outcome.prunedArchives > 0));
 
       for (const warning of outcome.warnings) {
         this.logger.warn(
@@ -141,7 +142,8 @@ export class RetentionTask {
       this.metrics.recordRetentionRun({
         removedEvents: outcome.removedEvents,
         archivedSnapshots: outcome.archivedSnapshots,
-        prunedArchives: outcome.prunedArchives
+        prunedArchives: outcome.prunedArchives,
+        perCamera: outcome.perCamera
       });
 
       this.logger.info(
@@ -160,7 +162,8 @@ export class RetentionTask {
                   optimize: this.options.vacuum.optimize === true,
                   target: this.options.vacuum.target
                 }
-              : undefined
+              : undefined,
+          perCamera: outcome.perCamera
         },
         'Retention task completed'
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface EventRecord {
 export interface RateLimitConfig {
   count: number;
   perMs: number;
+  cooldownMs?: number;
 }
 
 export interface EventSuppressionRule {

--- a/src/video/motionDetector.ts
+++ b/src/video/motionDetector.ts
@@ -217,6 +217,7 @@ export class MotionDetector {
       }
 
       if (this.backoffFrames > 0) {
+        metrics.incrementDetectorCounter('motion', 'backoffSuppressedFrames', 1);
         this.backoffFrames -= 1;
         this.activationFrames = 0;
         return;
@@ -235,6 +236,7 @@ export class MotionDetector {
 
       this.lastEventTs = ts;
       this.backoffFrames = effectiveBackoffFrames;
+      metrics.incrementDetectorCounter('motion', 'backoffActivations', 1);
 
       const payload: EventPayload = {
         ts,

--- a/src/video/yoloParser.ts
+++ b/src/video/yoloParser.ts
@@ -91,6 +91,11 @@ export function parseYoloDetections(
 
       const classLogit = accessor.get(detectionIndex, attributeIndex);
       const classProbability = sigmoid(classLogit);
+
+      if (!Number.isFinite(classProbability) || classProbability <= 0) {
+        continue;
+      }
+
       const score = clamp(objectness * classProbability, 0, 1);
 
       const threshold = resolveThreshold(classId);

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -67,9 +67,9 @@ describe('MetricsCounters', () => {
 
     registry.observeDetectorLatency('motion', 42);
     registry.observeDetectorLatency('motion', 120);
+    registry.recordPipelineRestart('ffmpeg', 'watchdog-timeout', { delayMs: 1500, attempt: 2 });
     registry.recordPipelineRestart('ffmpeg', 'watchdog-timeout');
-    registry.recordPipelineRestart('ffmpeg', 'watchdog-timeout');
-    registry.recordPipelineRestart('audio', 'spawn-error');
+    registry.recordPipelineRestart('audio', 'spawn-error', { delayMs: 800, attempt: 1 });
     registry.recordSuppressedEvent('rule-1', 'cooldown');
 
     const snapshot = registry.snapshot();
@@ -79,29 +79,25 @@ describe('MetricsCounters', () => {
     expect(snapshot.histograms['detector.motion.latency']['100-250']).toBe(1);
     expect(snapshot.pipelines.ffmpeg.restarts).toBe(2);
     expect(snapshot.pipelines.ffmpeg.byReason['watchdog-timeout']).toBe(2);
-    expect(snapshot.pipelines.ffmpeg.lastRestart).toEqual({
+    expect(snapshot.pipelines.ffmpeg.lastRestart).toMatchObject({
       reason: 'watchdog-timeout',
       attempt: null,
-      delayMs: null,
-      baseDelayMs: null,
-      minDelayMs: null,
-      maxDelayMs: null,
-      jitterMs: null
+      delayMs: null
     });
+    expect(snapshot.pipelines.ffmpeg.delayHistogram['1000-2000']).toBe(1);
+    expect(snapshot.pipelines.ffmpeg.attemptHistogram['2']).toBe(1);
     expect(snapshot.pipelines.audio.restarts).toBe(1);
-    expect(snapshot.pipelines.audio.lastRestart).toEqual({
+    expect(snapshot.pipelines.audio.lastRestart).toMatchObject({
       reason: 'spawn-error',
-      attempt: null,
-      delayMs: null,
-      baseDelayMs: null,
-      minDelayMs: null,
-      maxDelayMs: null,
-      jitterMs: null
+      attempt: 1,
+      delayMs: 800
     });
+    expect(snapshot.pipelines.audio.delayHistogram['500-1000']).toBe(1);
+    expect(snapshot.pipelines.audio.attemptHistogram['1']).toBe(1);
     expect(snapshot.suppression.total).toBe(1);
     expect(snapshot.suppression.byRule['rule-1']).toBe(1);
     expect(snapshot.suppression.byReason['cooldown']).toBe(1);
-    expect(snapshot.suppression.rules['rule-1']).toEqual({
+    expect(snapshot.suppression.rules['rule-1']).toMatchObject({
       total: 1,
       byReason: { cooldown: 1 }
     });
@@ -132,6 +128,9 @@ describe('MetricsCounters', () => {
     expect(snapshot.pipelines.ffmpeg.byChannel['video:lobby'].byReason['watchdog-timeout']).toBe(2);
     expect(snapshot.pipelines.ffmpeg.byChannel['video:parking'].restarts).toBe(1);
     expect(snapshot.pipelines.audio.byChannel['audio:mic'].restarts).toBe(1);
+    expect(snapshot.pipelines.ffmpeg.attemptHistogram['2']).toBe(1);
+    expect(snapshot.pipelines.ffmpeg.attemptHistogram['3']).toBe(1);
+    expect(snapshot.pipelines.ffmpeg.delayHistogram).toEqual({});
 
     expect(snapshot.suppression.rules['rule-1'].total).toBe(2);
     expect(snapshot.suppression.rules['rule-1'].byReason['cooldown']).toBe(2);
@@ -139,7 +138,7 @@ describe('MetricsCounters', () => {
     expect(snapshot.suppression.rules['rule-2'].byReason['rate-limit']).toBe(1);
   });
 
-  it('MetricsDetectorCounters tracks pose, face and object detector counters', () => {
+  it('MetricsLightCounters track detector counters for motion and light backoff', () => {
     const registry = new MetricsRegistry();
 
     registry.incrementDetectorCounter('pose', 'forecasts');
@@ -154,6 +153,10 @@ describe('MetricsCounters', () => {
     registry.incrementDetectorCounter('object', 'classifications', 5);
     registry.incrementDetectorCounter('object', 'threats', 2);
     registry.incrementDetectorCounter('object', 'detections', 7);
+    registry.incrementDetectorCounter('motion', 'backoffActivations', 2);
+    registry.incrementDetectorCounter('motion', 'backoffSuppressedFrames', 3);
+    registry.incrementDetectorCounter('light', 'backoffActivations');
+    registry.incrementDetectorCounter('light', 'backoffSuppressedFrames', 4);
 
     const snapshot = registry.snapshot();
 
@@ -171,6 +174,10 @@ describe('MetricsCounters', () => {
     expect(snapshot.detectors.object.counters.threats).toBe(2);
     expect(snapshot.detectors.object.counters.detections).toBe(7);
     expect(snapshot.detectors.object.lastRunAt).not.toBeNull();
+    expect(snapshot.detectors.motion.counters.backoffActivations).toBe(2);
+    expect(snapshot.detectors.motion.counters.backoffSuppressedFrames).toBe(3);
+    expect(snapshot.detectors.light.counters.backoffActivations).toBe(1);
+    expect(snapshot.detectors.light.counters.backoffSuppressedFrames).toBe(4);
   });
 });
 
@@ -201,7 +208,8 @@ describe('MetricsSnapshotEnrichment', () => {
       type: 'rate-limit',
       historyCount: 2,
       combinedHistoryCount: 5,
-      rateLimit: { count: 4, perMs: 1000 }
+      rateLimit: { count: 4, perMs: 1000 },
+      cooldownMs: 900
     });
     metrics.recordSuppressedEvent({
       ruleId: 'window-1',
@@ -220,7 +228,9 @@ describe('MetricsSnapshotEnrichment', () => {
     expect(snapshot.suppression.historyTotals.combinedHistoryCount).toBe(9);
     expect(snapshot.suppression.rules['window-1'].history.total).toBe(7);
     expect(snapshot.suppression.rules['window-1'].history.lastType).toBe('window');
+    expect(snapshot.suppression.rules['rate-1'].history.lastCooldownMs).toBe(900);
     expect(snapshot.suppression.lastEvent?.ruleId).toBe('window-1');
+    expect(snapshot.suppression.lastEvent?.cooldownMs).toBeNull();
 
     const unregister = registerHealthIndicator('metrics-snapshot', context => {
       expect(context.metrics?.suppression.total).toBe(3);
@@ -265,6 +275,12 @@ describe('MetricsSnapshotEnrichment', () => {
     expect(snapshot.pipelines.ffmpeg.attempts['3']).toBe(1);
     expect(snapshot.pipelines.ffmpeg.attempts['1']).toBe(1);
     expect(snapshot.pipelines.audio.attempts['2']).toBe(1);
+    expect(snapshot.pipelines.ffmpeg.delayHistogram['1000-2000']).toBe(1);
+    expect(snapshot.pipelines.ffmpeg.delayHistogram['50-100']).toBe(1);
+    expect(snapshot.pipelines.ffmpeg.attemptHistogram['3']).toBe(1);
+    expect(snapshot.pipelines.ffmpeg.attemptHistogram['1']).toBe(1);
+    expect(snapshot.pipelines.audio.delayHistogram['250-500']).toBe(1);
+    expect(snapshot.pipelines.audio.attemptHistogram['2']).toBe(1);
 
     const attemptHistogram = snapshot.histograms['pipeline.ffmpeg.restart.attempt'];
     expect(attemptHistogram?.['3']).toBe(1);

--- a/tests/readme_examples.test.ts
+++ b/tests/readme_examples.test.ts
@@ -44,12 +44,13 @@ describe('ReadmeExamples', () => {
     expect(readme).toContain('"restartJitterFactor"');
     expect(readme).toContain('Audio source recovering (reason=ffmpeg-missing|stream-idle)');
     expect(readme).toContain('pipelines.ffmpeg.byChannel');
+    expect(readme).toContain('guardian status --json');
     expect(readme).toContain('guardian health');
-    expect(readme).toContain('pnpm exec tsx src/cli.ts --health');
+    expect(readme).toContain('pnpm exec tsx src/cli.ts status --json');
 
     metrics.reset();
     const capture = createIo();
-    const exitCode = await runCli(['health'], capture.io);
+    const exitCode = await runCli(['status', '--json'], capture.io);
 
     expect(exitCode).toBe(0);
     const payload = JSON.parse(capture.stdout().trim());

--- a/tests/stubs/meyda.ts
+++ b/tests/stubs/meyda.ts
@@ -1,0 +1,6 @@
+export default {
+  extract: () => ({
+    rms: 0,
+    spectralCentroid: 0
+  })
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,8 @@ export default defineConfig({
   resolve: {
     alias: {
       'onnxruntime-node': path.resolve(__dirname, 'tests/stubs/onnxruntime-node.ts'),
-      pngjs: path.resolve(__dirname, 'tests/stubs/pngjs.ts')
+      pngjs: path.resolve(__dirname, 'tests/stubs/pngjs.ts'),
+      meyda: path.resolve(__dirname, 'tests/stubs/meyda.ts')
     }
   },
   test: {


### PR DESCRIPTION
## Summary
- track per-camera archive activity during retention runs and include channel-level snapshot directories when building retention options
- support cooldownMs on suppression rate limits so metadata and metrics capture the extra window alongside rate limits
- expose pipeline and retention metrics via a REST endpoint and render a dashboard widget that surfaces restart and snapshot health
- add a runtime-managed audio pipeline that hot reloads mic fallbacks and anomaly detector thresholds without restarting the guard process
- extend detector and pipeline metrics plus CLI health output to report motion/light backoff, restart histograms, and shutdown hook summaries, updating Docker/systemd healthchecks accordingly
- expand the README with live audio tuning guidance, retention maintenance commands, and the new JSON status workflow

## Testing
- `pnpm vitest run -t "AudioHotReloadThresholds"`
- `pnpm vitest run -t "CliJsonStatus"`
- `pnpm vitest run -t "MetricsLightCounters"`
- `pnpm vitest run -t "ReadmeExamples"`


------
https://chatgpt.com/codex/tasks/task_b_68d56ff1a1308328b8640d059527dde6