### PR TITLE
Enable runtime log level configuration and expose metrics histograms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ COPY . .
 STOPSIGNAL SIGTERM
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-  CMD pnpm exec tsx src/cli.ts status --json || exit 1
+  CMD pnpm exec tsx src/cli.ts --ready || exit 1
 
 CMD ["pnpm", "start"]

--- a/deploy/guardian.service
+++ b/deploy/guardian.service
@@ -9,13 +9,15 @@ Environment=GUARDIAN_CONFIG=/etc/guardian/config.json
 Environment=GUARDIAN_DATA_DIR=/var/lib/guardian
 Environment=PATH=/usr/local/bin:/usr/bin
 WorkingDirectory=/opt/guardian
+ExecStartPre=/usr/bin/env pnpm exec tsx src/cli.ts --health
 ExecStart=/usr/bin/env pnpm start
 ExecReload=/usr/bin/env pnpm exec tsx src/cli.ts status --json
 ExecStop=/usr/bin/env pnpm exec tsx src/cli.ts stop
+ExecStopPost=/usr/bin/env pnpm exec tsx scripts/db-maintenance.ts
 KillSignal=SIGTERM
 Restart=on-failure
 RestartSec=5
-TimeoutStopSec=30
+TimeoutStopSec=45
 
 [Install]
 WantedBy=multi-user.target

--- a/public/index.html
+++ b/public/index.html
@@ -407,6 +407,12 @@
             <dd id="stream-updated">—</dd>
           </dl>
         </section>
+        <section class="metrics-widget" aria-live="polite" aria-label="Threat summary">
+          <h2>Threat summary</h2>
+          <div id="threat-summary" class="metrics-grid">
+            <p class="meta" id="threat-summary-empty">Awaiting event data…</p>
+          </div>
+        </section>
         <section
           class="metrics-widget"
           aria-live="polite"
@@ -415,6 +421,16 @@
           <h2>Pipeline health</h2>
           <div id="pipeline-metrics" class="metrics-grid" aria-live="polite">
             <p class="meta" id="pipeline-metrics-empty">Loading metrics…</p>
+          </div>
+        </section>
+        <section
+          class="metrics-widget"
+          aria-live="polite"
+          aria-label="Channel status overview"
+        >
+          <h2>Channel status</h2>
+          <div id="channel-status" class="metrics-grid">
+            <p class="meta" id="channel-status-empty">No channel metrics available yet.</p>
           </div>
         </section>
         <section

--- a/scripts/db-maintenance.ts
+++ b/scripts/db-maintenance.ts
@@ -1,39 +1,92 @@
-import config from 'config';
+#!/usr/bin/env tsx
+import process from 'node:process';
 import path from 'node:path';
 import logger from '../src/logger.js';
-import { applyRetentionPolicy, vacuumDatabase } from '../src/db.js';
+import metrics from '../src/metrics/index.js';
+import configManager from '../src/config/index.js';
+import { runRetentionOnce } from '../src/tasks/retention.js';
 
-const retentionDays = config.has('database.retentionDays')
-  ? config.get<number>('database.retentionDays')
-  : 30;
-const snapshotDir = config.has('person.snapshotDir')
-  ? config.get<string>('person.snapshotDir')
-  : 'snapshots';
-const archiveDir = config.has('person.snapshotArchiveDir')
-  ? config.get<string>('person.snapshotArchiveDir')
-  : path.join(snapshotDir, 'archive');
+type MaintenanceSummary = {
+  removedEvents: number;
+  archivedSnapshots: number;
+  prunedArchives: number;
+  warnings: number;
+};
 
-const outcome = applyRetentionPolicy({
-  retentionDays,
-  snapshotDir,
-  archiveDir
+async function main() {
+  logger.info('Guardian maintenance starting');
+
+  const config = configManager.getConfig();
+  const module = await import('../src/run-guard.js');
+  const buildRetentionOptions = module.buildRetentionOptions as typeof import('../src/run-guard.js')['buildRetentionOptions'];
+
+  const retentionOptions = buildRetentionOptions({
+    retention: config.events?.retention,
+    video: config.video,
+    person: config.person,
+    logger
+  });
+
+  if (!retentionOptions) {
+    logger.info('Retention maintenance skipped (retention disabled)');
+    return;
+  }
+
+  const result = await runRetentionOnce({ ...retentionOptions, metrics });
+
+  if (result.skipped) {
+    logger.info('Retention maintenance skipped (retention disabled)');
+    return;
+  }
+
+  const totals = normalizeOutcome(result) ?? {
+    removedEvents: 0,
+    archivedSnapshots: 0,
+    prunedArchives: 0,
+    warnings: result.warnings.length
+  };
+
+  logger.info(
+    {
+      removedEvents: totals.removedEvents,
+      archivedSnapshots: totals.archivedSnapshots,
+      prunedArchives: totals.prunedArchives,
+      warnings: totals.warnings,
+      archiveDir: retentionOptions.archiveDir,
+      snapshotDirs: retentionOptions.snapshotDirs.map(dir => path.resolve(dir)),
+      vacuum: result.vacuum
+    },
+    'Database retention completed'
+  );
+
+  if (result.warnings.length > 0) {
+    for (const warning of result.warnings) {
+      logger.warn({ warning }, 'Retention maintenance warning');
+    }
+  }
+
+  if (result.vacuum.ran) {
+    logger.info({ vacuum: result.vacuum }, 'VACUUM completed');
+  } else {
+    logger.info({ vacuum: result.vacuum }, 'VACUUM skipped');
+  }
+}
+
+function normalizeOutcome(result: Awaited<ReturnType<typeof runRetentionOnce>>): MaintenanceSummary | null {
+  const outcome = result.outcome;
+  if (!outcome) {
+    return null;
+  }
+
+  return {
+    removedEvents: outcome.removedEvents,
+    archivedSnapshots: outcome.archivedSnapshots,
+    prunedArchives: outcome.prunedArchives,
+    warnings: result.warnings.length
+  } satisfies MaintenanceSummary;
+}
+
+main().catch(error => {
+  logger.error({ err: error }, 'Guardian maintenance failed');
+  process.exitCode = 1;
 });
-
-logger.info(
-  {
-    retentionDays,
-    removedEvents: outcome.removedEvents
-  },
-  'Database retention completed'
-);
-
-logger.info(
-  {
-    archiveDir,
-    archivedSnapshots: outcome.archivedSnapshots
-  },
-  'Snapshot archive rotation complete'
-);
-
-vacuumDatabase();
-logger.info('Vacuum completed');

--- a/scripts/vacuum.ts
+++ b/scripts/vacuum.ts
@@ -41,6 +41,14 @@ function parseArgs(argv: string[]): VacuumOptions {
       continue;
     }
 
+    if (arg.startsWith('--run=')) {
+      const mode = arg.split('=')[1];
+      if (mode === 'always' || mode === 'on-change') {
+        options.run = mode;
+      }
+      continue;
+    }
+
     if (arg.startsWith('--pragma=')) {
       const pragma = arg.slice('--pragma='.length);
       if (pragma) {
@@ -62,8 +70,8 @@ async function main() {
   const options = parseArgs(args);
 
   logger.info({ options }, 'running manual vacuum');
-  vacuumDatabase(options);
-  logger.info('vacuum completed');
+  const summary = vacuumDatabase(options);
+  logger.info({ vacuum: summary }, 'VACUUM completed');
 }
 
 main().catch(error => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -366,7 +366,7 @@ export function applyRetentionPolicy(options: RetentionPolicyOptions): Retention
   return { removedEvents, archivedSnapshots, prunedArchives, warnings, perCamera };
 }
 
-export function vacuumDatabase(options: VacuumOptions | VacuumMode = 'auto') {
+export function vacuumDatabase(options: VacuumOptions | VacuumMode = 'auto'): Required<VacuumOptions> {
   const normalized = normalizeVacuumOptions(options);
   const { run: _run, ...vacuum } = normalized;
 
@@ -395,6 +395,8 @@ export function vacuumDatabase(options: VacuumOptions | VacuumMode = 'auto') {
       db.exec(trimmed);
     }
   }
+
+  return normalized;
 }
 
 type SnapshotDirectory = {

--- a/src/video/personDetector.ts
+++ b/src/video/personDetector.ts
@@ -93,6 +93,7 @@ export class PersonDetector {
       }
 
       const detections = parseYoloDetections(output, meta, {
+        classIndex: PERSON_CLASS_INDEX,
         classIndices: this.classIndices,
         scoreThreshold: this.options.scoreThreshold ?? DEFAULT_SCORE_THRESHOLD,
         classScoreThresholds: this.classScoreThresholds,
@@ -130,6 +131,9 @@ export class PersonDetector {
           objectness: primaryDetection.objectness,
           classProbability: primaryDetection.classProbability,
           areaRatio: primaryDetection.areaRatio,
+          combinedLogit: primaryDetection.combinedLogit,
+          projectionIndex: primaryDetection.projectionIndex,
+          normalizedProjection: primaryDetection.normalizedProjection,
           thresholds: {
             score: this.options.scoreThreshold ?? DEFAULT_SCORE_THRESHOLD,
             nms: DEFAULT_NMS_IOU_THRESHOLD,
@@ -205,7 +209,10 @@ function serializeDetection(detection: YoloDetection) {
     bbox: detection.bbox,
     objectness: detection.objectness,
     classProbability: detection.classProbability,
-    areaRatio: detection.areaRatio
+    areaRatio: detection.areaRatio,
+    combinedLogit: detection.combinedLogit,
+    projectionIndex: detection.projectionIndex,
+    normalizedProjection: detection.normalizedProjection
   };
 }
 

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -190,6 +190,36 @@ describe('MetricsCounters', () => {
     expect(snapshot.detectors.light.counters.backoffActivations).toBe(1);
     expect(snapshot.detectors.light.counters.backoffSuppressedFrames).toBe(4);
   });
+
+  it('MetricsDetectorCounters exposes pipeline and detector histograms', () => {
+    const registry = new MetricsRegistry();
+
+    registry.recordPipelineRestart('ffmpeg', 'watchdog-timeout');
+    registry.recordPipelineRestart('ffmpeg', 'watchdog-timeout');
+    registry.recordPipelineRestart('audio', 'spawn-error');
+
+    registry.incrementDetectorCounter('motion', 'detections');
+    registry.incrementDetectorCounter('motion', 'detections', 4);
+    registry.recordDetectorError('motion', 'forecast-missed');
+
+    const snapshot = registry.snapshot();
+
+    expect(snapshot.histograms['pipeline.ffmpeg.restarts']).toMatchObject({
+      '1-2': 1,
+      '2-5': 1
+    });
+    expect(snapshot.histograms['pipeline.audio.restarts']).toMatchObject({
+      '1-2': 1
+    });
+    expect(snapshot.histograms['detector.motion.counter.detections']).toMatchObject({
+      '1-2': 1,
+      '5-10': 1
+    });
+    expect(snapshot.histograms['detector.motion.counter.errors']).toMatchObject({
+      '1-2': 1
+    });
+    expect(snapshot.histograms).toHaveProperty('logs.level');
+  });
 });
 
 describe('MetricsSnapshotEnrichment', () => {

--- a/tests/readme_examples.test.ts
+++ b/tests/readme_examples.test.ts
@@ -3,6 +3,7 @@ import { Writable } from 'node:stream';
 import fs from 'node:fs';
 import path from 'node:path';
 import { runCli } from '../src/cli.js';
+import { getLogLevel } from '../src/logger.js';
 import metrics from '../src/metrics/index.js';
 
 function readReadme() {
@@ -37,7 +38,7 @@ function createIo() {
 }
 
 describe('ReadmeExamples', () => {
-  it('ReadmeExamplesStayValid ensures README snippets and CLI output stay in sync', async () => {
+  it('ReadmeUsageExamples ensures README snippets and CLI output stay in sync', async () => {
     const readme = readReadme();
 
     expect(readme).toContain('"idleTimeoutMs"');
@@ -50,6 +51,10 @@ describe('ReadmeExamples', () => {
     expect(readme).toContain('guardian health');
     expect(readme).toContain('guardian retention run');
     expect(readme).toContain('pnpm exec tsx src/cli.ts status --json');
+    expect(readme).toContain('guardian log-level set debug');
+    expect(readme).toContain('Platform farklılıkları (ALSA/CoreAudio/Video4Linux)');
+    expect(readme).toContain('metrics.histograms.pipeline.ffmpeg.restarts');
+    expect(readme).toContain('pnpm tsx src/cli.ts --health');
 
     metrics.reset();
     const capture = createIo();
@@ -59,5 +64,21 @@ describe('ReadmeExamples', () => {
     const payload = JSON.parse(capture.stdout().trim());
     expect(payload.metrics.pipelines.ffmpeg.byChannel).toBeDefined();
     expect(payload.metrics.pipelines.audio.byChannel).toBeDefined();
+
+    const initialLevel = getLogLevel();
+    const setCapture = createIo();
+    const setExit = await runCli(['log-level', 'set', 'debug'], setCapture.io);
+    expect(setExit).toBe(0);
+    expect(setCapture.stdout()).toContain('Log level set to debug');
+    expect(getLogLevel()).toBe('debug');
+
+    const getCapture = createIo();
+    const getExit = await runCli(['log-level'], getCapture.io);
+    expect(getExit).toBe(0);
+    expect(getCapture.stdout().trim()).toBe('debug');
+
+    const restoreCapture = createIo();
+    const restoreExit = await runCli(['log-level', 'set', initialLevel], restoreCapture.io);
+    expect(restoreExit).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- allow the CLI to manage the logger level at runtime and hook configuration reloads into the logger
- expose pipeline and detector counter histograms, reserving histogram keys so health output advertises them by default
- expand the README with platform-specific guidance and updated quick start instructions covering the new log-level tooling

## Testing
- pnpm vitest run -t "MetricsDetectorCounters"
- pnpm vitest run -t "ReadmeUsageExamples"
- pnpm tsx src/cli.ts --health

------
https://chatgpt.com/codex/tasks/task_b_68d66d7d4ccc8328be9d18beefa786b8