### PR TITLE
Secure snapshot routes and document pipeline health commands

### DIFF
--- a/src/audio/source.ts
+++ b/src/audio/source.ts
@@ -533,6 +533,17 @@ export class AudioSource extends EventEmitter {
     this.clearWatchdogTimer();
     this.clearKillTimer();
 
+    if (this.options.type === 'ffmpeg') {
+      const input = typeof this.options.input === 'string' ? this.options.input.trim() : '';
+      if (!input) {
+        const error = new Error('Audio ffmpeg input is required');
+        this.emit('error', error);
+        this.scheduleRetry('stream-error', error);
+        return;
+      }
+      this.options.input = input;
+    }
+
     const sampleRate = this.options.sampleRate ?? DEFAULT_SAMPLE_RATE;
     const channels = this.options.channels ?? DEFAULT_CHANNELS;
     this.expectedSampleBytes = channels * 2;

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -16,6 +16,7 @@ export interface HttpServerOptions {
   staticDir?: string;
   faceRegistry?: FaceRegistry;
   createFaceRegistry?: () => Promise<FaceRegistry>;
+  snapshotDirs?: string[];
 }
 
 export interface HttpServerRuntime {
@@ -36,7 +37,8 @@ export async function startHttpServer(options: HttpServerOptions = {}): Promise<
     createFaceRegistry:
       options.createFaceRegistry ??
       (async () => FaceRegistry.create({ modelPath: path.resolve(process.cwd(), 'models/face.onnx') })),
-    metrics
+    metrics,
+    snapshotDirs: options.snapshotDirs
   });
 
   const server = http.createServer((req, res) => {

--- a/src/video/yoloParser.ts
+++ b/src/video/yoloParser.ts
@@ -242,9 +242,20 @@ export function parseYoloDetections(
     return b.score - a.score;
   });
 
-  const maxDetections = options.maxDetections ?? fused.length;
+  const rawMax = options.maxDetections;
 
-  return fused.slice(0, Math.max(1, maxDetections));
+  if (rawMax !== undefined && rawMax !== null) {
+    if (!Number.isFinite(rawMax)) {
+      return fused;
+    }
+    const truncated = Math.trunc(rawMax);
+    if (truncated <= 0) {
+      return [];
+    }
+    return fused.slice(0, truncated);
+  }
+
+  return fused;
 }
 
 function resolveClassIndices(options: ParseYoloDetectionsOptions, attributeCount: number): number[] {

--- a/tests/readme_examples.test.ts
+++ b/tests/readme_examples.test.ts
@@ -51,6 +51,8 @@ describe('ReadmeExamples', () => {
     expect(readme).toContain('pipelines.ffmpeg.watchdogRestarts');
     expect(readme).toContain('guardian daemon start');
     expect(readme).toContain('guardian daemon status --json');
+    expect(readme).toContain('guardian daemon pipelines list --json');
+    expect(readme).toContain('guardian daemon pipelines reset --channel');
     expect(readme).toContain('guardian daemon health');
     expect(readme).toContain('guardian daemon ready');
     expect(readme).toContain('guardian daemon hooks --reason');


### PR DESCRIPTION
## Summary
- ensure `guardian daemon pipelines list --json` sorts degraded channels by severity and add targeted CLI coverage for list/reset flows
- guard snapshot and diff routes with an allowlist, returning 403 for traversal attempts and 409 when image dimensions mismatch
- document pipeline list/reset workflows in the README and extend HTTP/API regression coverage for the new behaviours

## Testing
- pnpm vitest run -t CliPipelinesListJson --pool forks
- pnpm vitest run -t CliPipelinesReset --pool forks
- pnpm vitest run -t HttpApiSnapshotAllowlist --pool forks
- pnpm vitest run -t HttpSnapshotDiffDimensionMismatch --pool forks
- pnpm vitest run -t ReadmeExamples --pool forks

------
https://chatgpt.com/codex/tasks/task_b_68da2d6084448328b7d432cd1ca62f08